### PR TITLE
Fix bug in `comparePackageLockfiles` lint step

### DIFF
--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -169,11 +169,6 @@ struct Lint: AsyncParsableCommand {
                 }
             }
 
-            var result: [String] = []
-            for try await fileContents in group {
-                result.append(fileContents)
-            }
-
             return try await group.reduce(into: []) { accum, fileContents in
                 accum.append(fileContents)
             }


### PR DESCRIPTION
Mistake in 646c220 meant that we tried to iterate over the group twice; this is not something you’re meant to do and the second iteration yields no results.