### PR TITLE
Fix signature of `RoomReactions.send(params:)`

### DIFF
--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -1,11 +1,19 @@
 import Ably
 
 public protocol RoomReactions: AnyObject, Sendable, EmitsDiscontinuities {
-    func send(params: RoomReactionParams) async throws
+    func send(params: SendReactionParams) async throws
     func subscribe(bufferingPolicy: BufferingPolicy) -> Subscription<Reaction>
     var channel: ARTRealtimeChannelProtocol { get }
 }
 
-public struct RoomReactionParams: Sendable {
-    public init() {}
+public struct SendReactionParams: Sendable {
+    public var type: String
+    public var metadata: ReactionMetadata?
+    public var headers: ReactionHeaders?
+
+    public init(type: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {
+        self.type = type
+        self.metadata = metadata
+        self.headers = headers
+    }
 }


### PR DESCRIPTION
Marat noticed this mistake in 20e7f5f; I got the name of the type wrong and I forgot to add its properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the reactions system with a new `SendReactionParams` structure, allowing for more detailed information when sending reactions.
	- Introduced additional properties such as `type`, `metadata`, and `headers` to improve the expressiveness of the reaction parameters.

- **Bug Fixes**
	- Updated the `send` method to accept the new `SendReactionParams`, ensuring compatibility with the enhanced reactions functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->