### PR TITLE
Upgrade SwiftLint

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.55.1
+realm/SwiftLint@0.57.0
 nicklockwood/SwiftFormat@0.54.3

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -83,7 +83,7 @@ struct GenerateMatrices: ParsableCommand {
         ]
 
         // I’m assuming the JSONSerialization output has no newlines
-        let keyValue = try "matrix=\(String(decoding: JSONSerialization.data(withJSONObject: matrix), as: UTF8.self))"
+        let keyValue = try "matrix=\(String(data: JSONSerialization.data(withJSONObject: matrix), encoding: .utf8))"
         fputs("\(keyValue)\n", stderr)
         print(keyValue)
     }
@@ -173,6 +173,6 @@ struct Lint: AsyncParsableCommand {
 
     private func loadUTF8StringFromFile(at path: String) async throws -> String {
         let (data, _) = try await URLSession.shared.data(from: .init(filePath: path))
-        return String(decoding: data, as: UTF8.self)
+        return try String(data: data, encoding: .utf8)
     }
 }

--- a/Sources/BuildTool/String+Decoding.swift
+++ b/Sources/BuildTool/String+Decoding.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension String {
+    enum DecodingError: Swift.Error {
+        case decodingFailed
+    }
+
+    /// Like `init(data:encoding:)`, but indicates decoding failure by throwing an error instead of returning an optional.
+    init(data: Data, encoding: String.Encoding) throws {
+        guard let decoded = String(data: data, encoding: encoding) else {
+            throw DecodingError.decodingFailed
+        }
+
+        self = decoded
+    }
+}


### PR DESCRIPTION
To support Swift 6 syntax such as typed throws.

The changes are to address the violation of the `optional_data_string_conversion` rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated SwiftLint dependency to improve code quality and linting capabilities.
	- Introduced a new Swift extension for the `String` class to enhance error handling during data decoding.

- **Bug Fixes**
	- Improved string handling in JSON serialization by ensuring UTF-8 encoding is explicitly specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->