### PR TITLE
Remove Swift version check

### DIFF
--- a/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/Ably+Dependencies.swift
@@ -2,17 +2,9 @@ import Ably
 
 // TODO: remove "@unchecked Sendable" once https://github.com/ably/ably-cocoa/issues/1962 done
 
-#if swift(>=6)
-    // This @retroactive is needed to silence the Swift 6 compiler error "extension declares a conformance of imported type 'ARTRealtimeChannels' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'Ably' introduce this conformance in the future (…) add '@retroactive' to silence this warning". I don’t fully understand the implications of this but don’t really mind since both libraries are in our control.
-    extension ARTRealtime: RealtimeClientProtocol, @retroactive @unchecked Sendable {}
+// This @retroactive is needed to silence the Swift 6 compiler error "extension declares a conformance of imported type 'ARTRealtimeChannels' to imported protocol 'Sendable'; this will not behave correctly if the owners of 'Ably' introduce this conformance in the future (…) add '@retroactive' to silence this warning". I don’t fully understand the implications of this but don’t really mind since both libraries are in our control.
+extension ARTRealtime: RealtimeClientProtocol, @retroactive @unchecked Sendable {}
 
-    extension ARTRealtimeChannels: RealtimeChannelsProtocol, @retroactive @unchecked Sendable {}
+extension ARTRealtimeChannels: RealtimeChannelsProtocol, @retroactive @unchecked Sendable {}
 
-    extension ARTRealtimeChannel: RealtimeChannelProtocol, @retroactive @unchecked Sendable {}
-#else
-    extension ARTRealtime: RealtimeClientProtocol, @unchecked Sendable {}
-
-    extension ARTRealtimeChannels: RealtimeChannelsProtocol, @unchecked Sendable {}
-
-    extension ARTRealtimeChannel: RealtimeChannelProtocol, @unchecked Sendable {}
-#endif
+extension ARTRealtimeChannel: RealtimeChannelProtocol, @retroactive @unchecked Sendable {}


### PR DESCRIPTION
Missed this in 67f4563.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced consistent extensions for `ARTRealtime`, `ARTRealtimeChannels`, and `ARTRealtimeChannel`, enhancing compatibility across Swift versions.
  
- **Refactor**
	- Simplified code by removing conditional compilation directives, streamlining the implementation of extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->