### PR TITLE
Move error inside `RoomLifecycle`

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -412,7 +412,7 @@ actor MockRoomStatus: RoomStatus {
 
     private func createSubscription() -> MockSubscription<RoomStatusChange> {
         let subscription = MockSubscription<RoomStatusChange>(randomElement: {
-            RoomStatusChange(current: [.attached, .attached, .attached, .attached, .attaching, .attaching, .suspended].randomElement()!, previous: .attaching)
+            RoomStatusChange(current: [.attached, .attached, .attached, .attached, .attaching, .attaching, .suspended(error: .createUnknownError())].randomElement()!, previous: .attaching)
         }, interval: 8)
         mockSubscriptions.append(subscription)
         return subscription

--- a/Tests/AblyChatTests/Helpers/RoomLifecycle+Error.swift
+++ b/Tests/AblyChatTests/Helpers/RoomLifecycle+Error.swift
@@ -1,0 +1,21 @@
+import Ably
+import AblyChat
+
+extension RoomLifecycle {
+    var error: ARTErrorInfo? {
+        switch self {
+        case let .failed(error):
+            error
+        case let .suspended(error):
+            error
+        case .initialized,
+             .attached,
+             .attaching,
+             .detached,
+             .detaching,
+             .releasing,
+             .released:
+            nil
+        }
+    }
+}

--- a/Tests/AblyChatTests/Helpers/Subscription+RoomStatusChange.swift
+++ b/Tests/AblyChatTests/Helpers/Subscription+RoomStatusChange.swift
@@ -1,0 +1,34 @@
+import Ably
+import AblyChat
+
+/// Extensions for filtering a subscription by a given case, and then providing access to the values associated with these cases.
+///
+/// This provides better ergonomics than writing e.g. `failedStatusChange = await subscription.first { $0.isSuspended }`, because it means that you don’t have to write another `if case` (or equivalent) to get access to the associated value of `failedStatusChange.current`.
+extension Subscription where Element == RoomStatusChange {
+    struct StatusChangeWithError {
+        /// A status change whose `current` has an associated error; ``error`` provides access to this error.
+        var statusChange: RoomStatusChange
+        /// The error associated with `statusChange.current`.
+        var error: ARTErrorInfo
+    }
+
+    func suspendedElements() async -> AsyncCompactMapSequence<Subscription<RoomStatusChange>, Subscription<RoomStatusChange>.StatusChangeWithError> {
+        compactMap { statusChange in
+            if case let .suspended(error) = statusChange.current {
+                StatusChangeWithError(statusChange: statusChange, error: error)
+            } else {
+                nil
+            }
+        }
+    }
+
+    func failedElements() async -> AsyncCompactMapSequence<Subscription<RoomStatusChange>, Subscription<RoomStatusChange>.StatusChangeWithError> {
+        compactMap { statusChange in
+            if case let .failed(error) = statusChange.current {
+                StatusChangeWithError(statusChange: statusChange, error: error)
+            } else {
+                nil
+            }
+        }
+    }
+}


### PR DESCRIPTION
Lifecycle statuses have an error if and only if they have certain cases, so encode this constraint in the type system to avoid unnecessary unwraps.

Part of #12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced mock implementations for a chat client system, enhancing simulation of chat functionalities.
  - Added new methods for managing rooms, messages, and reactions, improving user interaction capabilities.
  - Enhanced state management in the `RoomLifecycleManager`, streamlining contributor lifecycle handling.

- **Bug Fixes**
  - Improved error handling in state transitions for chat room contributors, increasing system reliability.

- **Tests**
  - Updated tests for the `RoomLifecycleManager` to reflect new error handling and state management features, ensuring robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->