### PR TITLE
[ECO-4987] Implement lifecycle behaviour that relates to an ongoing operation

### DIFF
--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -514,6 +514,11 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
             break
         }
 
+        // CHA-RL1d
+        if let currentOperationID = status.operationID {
+            try? await waitForCompletionOfOperationWithID(currentOperationID, waitingOperationID: operationID)
+        }
+
         // CHA-RL1e
         changeStatus(to: .attaching(attachOperationID: operationID))
 

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -706,7 +706,12 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
             // CHA-RL3b
             changeStatus(to: .released)
             return
-        case .releasing, .initialized, .attached, .attaching, .detaching, .suspended, .failed:
+        case let .releasing(releaseOperationID):
+            // CHA-RL3c
+            // See note on waitForCompletionOfOperationWithID for the current need for this force try
+            // swiftlint:disable:next force_try
+            return try! await waitForCompletionOfOperationWithID(releaseOperationID, waitingOperationID: operationID)
+        case .initialized, .attached, .attaching, .detaching, .suspended, .failed:
             break
         }
 

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -549,6 +549,7 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
             break
         }
 
+        // CHA-RL3c
         changeStatus(to: .releasing)
 
         // CHA-RL3d

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -535,7 +535,7 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
 
     // MARK: - RELEASE operation
 
-    /// Implementes CHA-RL3’s RELEASE operation.
+    /// Implements CHA-RL3’s RELEASE operation.
     internal func performReleaseOperation() async {
         switch status {
         case .released:

--- a/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
@@ -28,14 +28,14 @@ struct RoomLifecycleManagerTests {
     }
 
     private func createManager(
-        forTestingWhatHappensWhenCurrentlyIn current: RoomLifecycle? = nil,
+        forTestingWhatHappensWhenCurrentlyIn status: RoomLifecycleManager<MockRoomLifecycleContributor>.Status? = nil,
         forTestingWhatHappensWhenHasOperationInProgress hasOperationInProgress: Bool? = nil,
         forTestingWhatHappensWhenHasPendingDiscontinuityEvents pendingDiscontinuityEvents: [MockRoomLifecycleContributor.ID: [ARTErrorInfo]]? = nil,
         contributors: [MockRoomLifecycleContributor] = [],
         clock: SimpleClock = MockSimpleClock()
     ) async -> RoomLifecycleManager<MockRoomLifecycleContributor> {
         await .init(
-            testsOnly_current: current,
+            testsOnly_status: status,
             testsOnly_hasOperationInProgress: hasOperationInProgress,
             testsOnly_pendingDiscontinuityEvents: pendingDiscontinuityEvents,
             contributors: contributors,
@@ -911,9 +911,9 @@ struct RoomLifecycleManagerTests {
             createContributor(initialState: .detached),
         ]
 
-        let initialManagerState = RoomLifecycle.initialized // arbitrary non-ATTACHED
+        let initialManagerStatus = RoomLifecycleManager<MockRoomLifecycleContributor>.Status.initialized // arbitrary non-ATTACHED
         let manager = await createManager(
-            forTestingWhatHappensWhenCurrentlyIn: initialManagerState,
+            forTestingWhatHappensWhenCurrentlyIn: initialManagerStatus,
             forTestingWhatHappensWhenHasOperationInProgress: false,
             contributors: contributors
         )
@@ -932,7 +932,7 @@ struct RoomLifecycleManagerTests {
         }
 
         // Then: The room status does not change
-        #expect(await manager.current == initialManagerState)
+        #expect(await manager.current == initialManagerStatus.toRoomLifecycle)
     }
 
     // @specPartial CHA-RL4b9 - Haven’t implemented the part that refers to "transient disconnect timeouts"; TODO do this (https://github.com/ably-labs/ably-chat-swift/issues/48). Nor have I implemented "the room enters the RETRY loop"; TODO do this (https://github.com/ably-labs/ably-chat-swift/issues/51)

--- a/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
@@ -871,7 +871,7 @@ struct RoomLifecycleManagerTests {
     // @specOneOf(1/2) CHA-RL4b8
     @Test
     func contributorAttachedEvent_withNoOperationInProgress_roomNotAttached_allContributorsAttached() async throws {
-        // Given: A RoomLifecycleManager, not in the ATTACHED state, all of whose contributors are in the ATTACHED state (to satisfy the condition of CHA-RL4b8; for the purposes of this test I don’t care that they’re in this state even _before_ the state change of the When)
+        // Given: A RoomLifecycleManager, with no operation in progress and not in the ATTACHED state, all of whose contributors are in the ATTACHED state (to satisfy the condition of CHA-RL4b8; for the purposes of this test I don’t care that they’re in this state even _before_ the state change of the When)
         let contributors = [
             createContributor(initialState: .attached),
             createContributor(initialState: .attached),
@@ -905,7 +905,7 @@ struct RoomLifecycleManagerTests {
     // @specOneOf(2/2) CHA-RL4b8 - Tests that the specified side effect doesn’t happen if part of the condition (i.e. all contributors now being ATTACHED) is not met
     @Test
     func contributorAttachedEvent_withNoOperationInProgress_roomNotAttached_notAllContributorsAttached() async throws {
-        // Given: A RoomLifecycleManager, not in the ATTACHED state, one of whose contributors is not in the ATTACHED state state (to simulate the condition of CHA-RL4b8 not being met; for the purposes of this test I don’t care that they’re in this state even _before_ the state change of the When)
+        // Given: A RoomLifecycleManager, with no operation in progress and not in the ATTACHED state, one of whose contributors is not in the ATTACHED state state (to simulate the condition of CHA-RL4b8 not being met; for the purposes of this test I don’t care that they’re in this state even _before_ the state change of the When)
         let contributors = [
             createContributor(initialState: .attached),
             createContributor(initialState: .detached),


### PR DESCRIPTION
Does a bunch of groundwork, and then implements spec points CHA-RL1d and CHA-RL3c. See commit mesages for more details.

Resolves #52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced room lifecycle management with a new status tracking system.
	- Improved handling of contributor states and operations, including attach, detach, and release.

- **Bug Fixes**
	- Refined logic for managing pending events and error handling during contributor detachment.

- **Tests**
	- Updated tests to reflect changes in room lifecycle operations and added new test cases for improved coverage and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->