### PR TITLE
[ECO-4945] Spec complete for Ephemeral Room Reactions

### DIFF
--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -88,6 +88,6 @@ enum ReactionType: String, CaseIterable {
 
 extension Reaction {
     var displayedText: String {
-        ReactionType(rawValue: type)?.emoji ?? ReactionType.idk.emoji
+        type
     }
 }

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -69,7 +69,7 @@ actor MockRoom: Room {
     private var mockSubscriptions: [MockSubscription<RoomStatusChange>] = []
 
     func attach() async throws {
-        fatalError("Not yet implemented")
+        print("Mock client attached to room with roomID: \(roomID)")
     }
 
     func detach() async throws {
@@ -165,7 +165,7 @@ actor MockRoomReactions: RoomReactions {
     private func createSubscription() -> MockSubscription<Reaction> {
         let subscription = MockSubscription<Reaction>(randomElement: {
             Reaction(
-                type: ReactionType.allCases.randomElement()!.rawValue,
+                type: ReactionType.allCases.randomElement()!.emoji,
                 metadata: [:],
                 headers: [:],
                 createdAt: Date(),

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -1,0 +1,87 @@
+import Ably
+
+// TODO: This class errors with "Task-isolated value of type '() async throws -> ()' passed as a strongly transferred parameter; later accesses could race". Adding @MainActor fixes this, revisit as part of https://github.com/ably-labs/ably-chat-swift/issues/83
+@MainActor
+internal final class DefaultRoomReactions: RoomReactions, EmitsDiscontinuities {
+    private let roomID: String
+    public let featureChannel: FeatureChannel
+    private let logger: InternalLogger
+    private let clientID: String
+
+    internal nonisolated var channel: any RealtimeChannelProtocol {
+        featureChannel.channel
+    }
+
+    internal init(featureChannel: FeatureChannel, clientID: String, roomID: String, logger: InternalLogger) {
+        self.roomID = roomID
+        self.featureChannel = featureChannel
+        self.logger = logger
+        self.clientID = clientID
+    }
+
+    // (CHA-ER3) Ephemeral room reactions are sent to Ably via the Realtime connection via a send method.
+    // (CHA-ER3a) Reactions are sent on the channel using a message in a particular format - see spec for format.
+    internal func send(params: SendReactionParams) async throws {
+        let extras = ["headers": params.headers ?? [:]] as ARTJsonCompatible
+        channel.publish(RoomReactionEvents.reaction.rawValue, data: params.asQueryItems(), extras: extras)
+    }
+
+    // (CHA-ER4) A user may subscribe to reaction events in Realtime.
+    // (CHA-ER4a) A user may provide a listener to subscribe to reaction events. This operation must have no side-effects in relation to room or underlying status. When a realtime message with name roomReaction is received, this message is converted into a reaction object and emitted to subscribers.
+    internal func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<Reaction> {
+        let subscription = Subscription<Reaction>(bufferingPolicy: bufferingPolicy)
+
+        // (CHA-ER4c) Realtime events with an unknown name shall be silently discarded.
+        channel.subscribe(RoomReactionEvents.reaction.rawValue) { [clientID, logger] message in
+            Task {
+                do {
+                    guard let data = message.data as? [String: Any],
+                          let reactionType = data["type"] as? String
+                    else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data or text")
+                    }
+
+                    guard let messageClientID = message.clientId else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without clientId")
+                    }
+
+                    guard let timestamp = message.timestamp else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without timestamp")
+                    }
+
+                    guard let extras = try message.extras?.toJSON() else {
+                        throw ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without extras")
+                    }
+
+                    let metadata = data["metadata"] as? Metadata
+                    let headers = extras["headers"] as? Headers
+
+                    // (CHA-ER4d) Realtime events that are malformed (unknown fields should be ignored) shall not be emitted to listeners.
+                    let reaction = Reaction(
+                        type: reactionType,
+                        metadata: metadata ?? .init(),
+                        headers: headers ?? .init(),
+                        createdAt: timestamp,
+                        clientID: messageClientID,
+                        isSelf: messageClientID == clientID
+                    )
+
+                    subscription.emit(reaction)
+                } catch {
+                    logger.log(message: "Error processing incoming reaction message: \(error)", level: .error)
+                }
+            }
+        }
+
+        return subscription
+    }
+
+    // (CHA-ER5) Users may subscribe to discontinuity events to know when there’s been a break in reactions that they need to resolve. Their listener will be called when a discontinuity event is triggered from the room lifecycle.
+    internal func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
+        await featureChannel.subscribeToDiscontinuities()
+    }
+
+    private enum RoomReactionsError: Error {
+        case noReferenceToSelf
+    }
+}

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -1,3 +1,7 @@
 internal enum MessageEvent: String {
     case created = "message.created"
 }
+
+internal enum RoomReactionEvents: String {
+    case reaction = "roomReaction"
+}

--- a/Sources/AblyChat/Reaction.swift
+++ b/Sources/AblyChat/Reaction.swift
@@ -3,6 +3,7 @@ import Foundation
 public typealias ReactionHeaders = Headers
 public typealias ReactionMetadata = Metadata
 
+// (CHA-ER2) A Reaction corresponds to a single reaction in a chat room. This is analogous to a single user-specified message on an Ably channel (NOTE: not a ProtocolMessage).
 public struct Reaction: Sendable {
     public var type: String
     public var metadata: ReactionMetadata

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -17,7 +17,10 @@ internal enum RoomFeature {
         case .messages:
             // (CHA-M1) Chat messages for a Room are sent on a corresponding realtime channel <roomId>::$chat::$chatMessages. For example, if your room id is my-room then the messages channel will be my-room::$chat::$chatMessages.
             "chatMessages"
-        case .typing, .reactions, .presence, .occupancy:
+        case .reactions:
+            // (CHA-ER1) Reactions for a Room are sent on a corresponding realtime channel <roomId>::$chat::$reactions. For example, if your room id is my-room then the reactions channel will be my-room::$chat::$reactions.
+            "reactions"
+        case .typing, .presence, .occupancy:
             // We’ll add these, with reference to the relevant spec points, as we implement these features
             fatalError("Don’t know channel name suffix for room feature \(self)")
         }

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -17,3 +17,13 @@ public struct SendReactionParams: Sendable {
         self.headers = headers
     }
 }
+
+internal extension SendReactionParams {
+    // Same as `ARTDataQuery.asQueryItems` from ably-cocoa.
+    func asQueryItems() -> [String: String] {
+        var dict: [String: String] = [:]
+        dict["type"] = "\(type)"
+        dict["metadata"] = "\(metadata ?? [:])"
+        return dict
+    }
+}

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -71,6 +71,16 @@ public struct Subscription<Element: Sendable>: Sendable, AsyncSequence {
         }
     }
 
+    // TODO: https://github.com/ably-labs/ably-chat-swift/issues/36 Revisit how we want to unsubscribe to fulfil CHA-M4b & CHA-ER4b. I think exposing this publicly for all Subscription types is suitable.
+    public func finish() {
+        switch mode {
+        case let .default(_, continuation):
+            continuation.finish()
+        case .mockAsyncSequence:
+            fatalError("`finish` cannot be called on a Subscription that was created using init(mockAsyncSequence:)")
+        }
+    }
+
     public struct AsyncIterator: AsyncIteratorProtocol {
         fileprivate enum Mode {
             case `default`(iterator: AsyncStream<Element>.AsyncIterator)

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -1,0 +1,82 @@
+import Ably
+@testable import AblyChat
+import Testing
+
+struct DefaultRoomReactionsTests {
+    // @spec CHA-ER1
+    @Test
+    func init_channelNameIsSetAsReactionsChannelName() async throws {
+        // Given
+        let channel = MockRealtimeChannel(name: "basketball::$chat::$reactions")
+        let featureChannel = MockFeatureChannel(channel: channel)
+
+        // When
+        let defaultRoomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
+
+        // Then
+        #expect(defaultRoomReactions.channel.name == "basketball::$chat::$reactions")
+    }
+
+    // @spec CHA-ER3a
+    @Test
+    func reactionsAreSentInTheCorrectFormat() async throws {
+        // channel name and roomID values are arbitrary
+        // Given
+        let channel = MockRealtimeChannel(name: "basketball::$chat::$reactions")
+        let featureChannel = MockFeatureChannel(channel: channel)
+
+        // When
+        let defaultRoomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
+
+        let sendReactionParams = SendReactionParams(
+            type: "like",
+            metadata: ["test": MetadataValue.string("test")],
+            headers: ["test": HeadersValue.string("test")]
+        )
+
+        // When
+        try await defaultRoomReactions.send(params: sendReactionParams)
+
+        // Then
+        #expect(channel.lastMessagePublishedName == RoomReactionEvents.reaction.rawValue)
+        #expect(channel.lastMessagePublishedData as? [String: String] == sendReactionParams.asQueryItems())
+        #expect(channel.lastMessagePublishedExtras as? Dictionary == ["headers": sendReactionParams.headers])
+    }
+
+    // @spec CHA-ER4
+    @Test
+    func subscribe_returnsSubscription() async throws {
+        // all setup values here are arbitrary
+        // Given
+        let channel = MockRealtimeChannel(name: "basketball::$chat::$reactions")
+        let featureChannel = MockFeatureChannel(channel: channel)
+
+        // When
+        let defaultRoomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
+
+        // When
+        let subscription: Subscription<Reaction>? = await defaultRoomReactions.subscribe(bufferingPolicy: .unbounded)
+
+        // Then
+        #expect(subscription != nil)
+    }
+
+    // @spec CHA-ER5
+    @Test
+    func subscribeToDiscontinuities() async throws {
+        // all setup values here are arbitrary
+        // Given: A DefaultRoomReactions instance
+        let channel = MockRealtimeChannel()
+        let featureChannel = MockFeatureChannel(channel: channel)
+        let roomReactions = await DefaultRoomReactions(featureChannel: featureChannel, clientID: "mockClientId", roomID: "basketball", logger: TestLogger())
+
+        // When: The feature channel emits a discontinuity through `subscribeToDiscontinuities`
+        let featureChannelDiscontinuity = ARTErrorInfo.createUnknownError() // arbitrary
+        let messagesDiscontinuitySubscription = await roomReactions.subscribeToDiscontinuities()
+        await featureChannel.emitDiscontinuity(featureChannelDiscontinuity)
+
+        // Then: The DefaultRoomReactions instance emits this discontinuity through `subscribeToDiscontinuities`
+        let messagesDiscontinuity = try #require(await messagesDiscontinuitySubscription.first { _ in true })
+        #expect(messagesDiscontinuity === featureChannelDiscontinuity)
+    }
+}

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -11,6 +11,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -32,6 +33,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -68,6 +70,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -100,6 +103,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -126,6 +130,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -146,6 +151,7 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -8,6 +8,11 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
 
     var properties: ARTChannelProperties { .init(attachSerial: attachSerial, channelSerial: channelSerial) }
 
+    // I don't see why the nonisolated(unsafe) keyword would cause a problem when used for tests in this context.
+    nonisolated(unsafe) var lastMessagePublishedName: String?
+    nonisolated(unsafe) var lastMessagePublishedData: Any?
+    nonisolated(unsafe) var lastMessagePublishedExtras: (any ARTJsonCompatible)?
+
     init(
         name: String? = nil,
         properties: ARTChannelProperties = .init(),
@@ -199,8 +204,10 @@ final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
         fatalError("Not implemented")
     }
 
-    func publish(_: String?, data _: Any?, extras _: (any ARTJsonCompatible)?) {
-        fatalError("Not implemented")
+    func publish(_ name: String?, data: Any?, extras: (any ARTJsonCompatible)?) {
+        lastMessagePublishedName = name
+        lastMessagePublishedExtras = extras
+        lastMessagePublishedData = data
     }
 
     func publish(_: String?, data _: Any?, extras _: (any ARTJsonCompatible)?, callback _: ARTCallback? = nil) {


### PR DESCRIPTION
Spec complete for Ephemeral Room Reactions in line with [1]. 

`CHA-ER3b` & `CHA-ER3c` have not been implemented despite being outlined in [1], as per the ADR at [2]. 

Example app has also been updated to support both a working and mock implementation of the Chat app. Video shows the example app being connected to a real ChatAPI/Realtime instance:

https://github.com/user-attachments/assets/24fe3264-46b5-4ebc-b2fa-c205e296d42f


[1] - https://sdk.ably.com/builds/ably/specification/pull/200/chat-features/
[2] - https://ably.atlassian.net/wiki/spaces/CHA/pages/3438116905/CHADR-066+Removing+Reserved+Keyspace#Solution


Unit tests are not exhaustive, will add more as part of https://github.com/ably-labs/ably-chat-swift/issues/88 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a mode-based system for managing chat client connections (mock/live).
  - Added new asynchronous functions for handling chat room interactions and reactions.
  - Enhanced visual effects for reactions with new properties.
  - Added a new `Reaction` struct for representing reactions in chat.
  - Implemented a subscription system for handling reactions in integration tests.

- **Bug Fixes**
  - Improved error handling for accessing reactions when not enabled.
  - Updated logic to simplify extraction of headers in message subscriptions.

- **Tests**
  - Added unit tests for the `DefaultRoomReactions` class to validate functionalities.
  - Enhanced mock channel to track the last published message details.
  - Improved integration tests to include reaction handling and validation.

- **Documentation**
  - Updated comments and TODOs for future improvements in message subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->