### PR TITLE
Update duplicate spec points

### DIFF
--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -51,7 +51,7 @@ internal final class DefaultMessages: Messages, EmitsDiscontinuities {
 
         // (CHA-M4c) When a realtime message with name set to message.created is received, it is translated into a message event, which contains a type field with the event type as well as a message field containing the Message Struct. This event is then broadcast to all subscribers.
         // (CHA-M4d) If a realtime message with an unknown name is received, the SDK shall silently discard the message, though it may log at DEBUG or TRACE level.
-        // (CHA-M5d) Incoming realtime events that are malformed (unknown field should be ignored) shall not be emitted to subscribers.
+        // (CHA-M5k) Incoming realtime events that are malformed (unknown field should be ignored) shall not be emitted to subscribers.
         channel.subscribe(MessageEvent.created.rawValue) { message in
             Task {
                 // TODO: Revisit errors thrown as part of https://github.com/ably-labs/ably-chat-swift/issues/32

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -715,7 +715,7 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
             break
         }
 
-        // CHA-RL3c
+        // CHA-RL3l
         changeStatus(to: .releasing(releaseOperationID: operationID))
 
         // CHA-RL3d

--- a/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/RoomLifecycleManagerTests.swift
@@ -650,7 +650,7 @@ struct RoomLifecycleManagerTests {
         #expect(await contributor.channel.detachCallCount == 0)
     }
 
-    // @specPartial CHA-RL3c - This is marked as specPartial because at time of writing the spec point CHA-RL3c has been accidentally duplicated to specify two separate behaviours. TODO: change this one to @spec once spec fixed (see discussion in https://github.com/ably/specification/pull/200#discussion_r1763770348)
+    // @spec CHA-RL3c
     @Test
     func release_whenReleasing() async throws {
         // Given: A RoomLifecycleManager with a RELEASE lifecycle operation in progress, and hence in the RELEASING state
@@ -696,7 +696,7 @@ struct RoomLifecycleManagerTests {
         #expect(await contributor.channel.detachCallCount == 1)
     }
 
-    // @specPartial CHA-RL3c - Haven’t implemented the part that refers to "transient disconnect timeouts"; TODO do this (https://github.com/ably-labs/ably-chat-swift/issues/48)
+    // @specPartial CHA-RL3l - Haven’t implemented the part that refers to "transient disconnect timeouts"; TODO do this (https://github.com/ably-labs/ably-chat-swift/issues/48)
     @Test
     func release_transitionsToReleasing() async throws {
         // Given: A RoomLifecycleManager, with a contributor on whom calling `detach()` will not complete until after the "Then" part of this test (the motivation for this is to suppress the room from transitioning to RELEASED, so that we can assert its current state as being RELEASING)


### PR DESCRIPTION
The duplicate spec points were renamed in https://github.com/ably/specification/pull/200/commits/0e5ab980a14869b253217b5618d360dd0e6e38c8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for message subscriptions, improving clarity in error reporting.
	- Improved detachment logic for contributors during the release operation.

- **Bug Fixes**
	- Fixed issues with state transitions and error conditions in the room lifecycle manager.

- **Tests**
	- Added new test cases and enhanced existing ones for better coverage of room lifecycle operations and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->