### PR TITLE
Fix decoding of `Message.createdAt`

### DIFF
--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -127,7 +127,14 @@ internal final class ChatAPI: Sendable {
 }
 
 internal struct DictionaryDecoder {
-    private let decoder = JSONDecoder()
+    private let decoder = {
+        var decoder = JSONDecoder()
+
+        // Ably’s REST APIs always serialise dates as milliseconds since Unix epoch
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+
+        return decoder
+    }()
 
     // Function to decode from a dictionary
     internal func decode<T: Decodable>(_: T.Type, from dictionary: NSDictionary) throws -> T {

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -170,7 +170,7 @@ struct ChatAPITests {
                     clientID: "random",
                     roomID: roomId,
                     text: "hello",
-                    createdAt: nil,
+                    createdAt: .init(timeIntervalSince1970: 1_730_943_049.269),
                     metadata: [:],
                     headers: [:]
                 ),

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -99,6 +99,7 @@ extension MockHTTPPaginatedResponse {
             [
                 "clientId": "random",
                 "timeserial": "3446456",
+                "createdAt": 1_730_943_049_269,
                 "roomId": "basketball::$chat::$chatMessages",
                 "text": "hello",
                 "metadata": [:],


### PR DESCRIPTION
**Note: This PR is based on top of #101; please review that one first.**

Noticed this when writing an integration test for `getPreviousMessages`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for message sending, ensuring stricter validation of metadata and headers.
	- Improved date decoding process to align with Ably's REST API format.

- **Bug Fixes**
	- Updated tests to accurately reflect the `createdAt` timestamp for messages and ensure robust error handling scenarios.

- **Tests**
	- Added new test cases to validate message sending and error handling based on metadata and headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->