### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     # From actions/cache documentation linked to below
     env:
@@ -39,7 +39,7 @@ jobs:
       - run: swift run BuildTool lint
 
   spec-coverage:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-matrices:
-    runs-on: macos-latest
+    runs-on: macos-15
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   check-spm:
     name: SPM (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: generate-matrices
     strategy:
       fail-fast: false
@@ -88,7 +88,7 @@ jobs:
 
   check-xcode:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: generate-matrices
 
     strategy:
@@ -106,7 +106,7 @@ jobs:
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: generate-matrices
 
     strategy:

--- a/Sources/BuildTool/Platform.swift
+++ b/Sources/BuildTool/Platform.swift
@@ -11,9 +11,9 @@ enum Platform: String, CaseIterable {
         case .macOS:
             .fixed(platform: "macOS")
         case .iOS:
-            .lookup(destinationPredicate: .init(runtime: "iOS-17-5", deviceType: "iPhone-15"))
+            .lookup(destinationPredicate: .init(runtime: "iOS-18-0", deviceType: "iPhone-16"))
         case .tvOS:
-            .lookup(destinationPredicate: .init(runtime: "tvOS-17-5", deviceType: "Apple-TV-4K-3rd-generation-4K"))
+            .lookup(destinationPredicate: .init(runtime: "tvOS-18-0", deviceType: "Apple-TV-4K-3rd-generation-4K"))
         }
     }
 


### PR DESCRIPTION
A recent GitHub policy change (https://github.com/actions/runner-images/issues/10703) means that Xcode 16 is now only available on macOS 15 runners. (macos-latest still points to macOS 14, hence needing to now be explicit about OS version.)

I’ve had to bump the iOS and tvOS versions used for testing, to match what’s available on these runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration to run jobs on `macos-15` instead of `macos-latest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->