### PR TITLE
[ECO-4982] Some groundwork for integrating room lifecycle manager

### DIFF
--- a/Example/AblyChatExample/Mocks/MockRealtime.swift
+++ b/Example/AblyChatExample/Mocks/MockRealtime.swift
@@ -18,10 +18,6 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
             fatalError("Not implemented")
         }
 
-        func get(_: String) -> Channel {
-            fatalError("Not implemented")
-        }
-
         func exists(_: String) -> Bool {
             fatalError("Not implemented")
         }

--- a/Sources/AblyChat/AblyCocoaExtensions/Ably+Concurrency.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/Ably+Concurrency.swift
@@ -4,27 +4,27 @@ import Ably
 // TODO: remove once we improve this experience in ably-cocoa (https://github.com/ably/ably-cocoa/issues/1967)
 
 internal extension ARTRealtimeChannelProtocol {
-    func attachAsync() async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, _>) in
+    func attachAsync() async throws(ARTErrorInfo) {
+        try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
             attach { error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    continuation.resume(returning: .failure(error))
                 } else {
-                    continuation.resume()
+                    continuation.resume(returning: .success(()))
                 }
             }
-        }
+        }.get()
     }
 
-    func detachAsync() async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, _>) in
+    func detachAsync() async throws(ARTErrorInfo) {
+        try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
             detach { error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    continuation.resume(returning: .failure(error))
                 } else {
-                    continuation.resume()
+                    continuation.resume(returning: .success(()))
                 }
             }
-        }
+        }.get()
     }
 }

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -8,10 +8,6 @@ internal final class ChatAPI: Sendable {
         self.realtime = realtime
     }
 
-    internal func getChannel(_ name: String) -> any RealtimeChannelProtocol {
-        realtime.getChannel(name)
-    }
-
     // (CHA-M6) Messages should be queryable from a paginated REST API.
     internal func getMessages(roomId: String, params: QueryOptions) async throws -> any PaginatedResult<Message> {
         let endpoint = "\(apiVersion)/rooms/\(roomId)/messages"

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -14,9 +14,8 @@ public protocol RealtimeClientProtocol: ARTRealtimeProtocol, Sendable {
 public protocol RealtimeChannelsProtocol: ARTRealtimeChannelsProtocol, Sendable {
     associatedtype Channel: RealtimeChannelProtocol
 
-    // It’s not clear to me why ARTRealtimeChannelsProtocol doesn’t include these functions (https://github.com/ably/ably-cocoa/issues/1968).
+    // It’s not clear to me why ARTRealtimeChannelsProtocol doesn’t include this function (https://github.com/ably/ably-cocoa/issues/1968).
     func get(_ name: String, options: ARTRealtimeChannelOptions) -> Channel
-    func get(_ name: String) -> Channel
 }
 
 /// Expresses the requirements of the object returned by ``RealtimeChannelsProtocol.get(_:)``.

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -14,7 +14,7 @@ public protocol RealtimeClientProtocol: ARTRealtimeProtocol, Sendable {
 public protocol RealtimeChannelsProtocol: ARTRealtimeChannelsProtocol, Sendable {
     associatedtype Channel: RealtimeChannelProtocol
 
-    // It’s not clear to me why ARTRealtimeChannelsProtocol doesn’t include this property (https://github.com/ably/ably-cocoa/issues/1968).
+    // It’s not clear to me why ARTRealtimeChannelsProtocol doesn’t include these functions (https://github.com/ably/ably-cocoa/issues/1968).
     func get(_ name: String, options: ARTRealtimeChannelOptions) -> Channel
     func get(_ name: String) -> Channel
 }

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -5,4 +5,23 @@ internal enum RoomFeature {
     case reactions
     case occupancy
     case typing
+
+    internal func channelNameForRoomID(_ roomID: String) -> String {
+        "\(roomID)::$chat::$\(channelNameSuffix)"
+    }
+
+    private var channelNameSuffix: String {
+        switch self {
+        case .messages:
+            // (CHA-M1) Chat messages for a Room are sent on a corresponding realtime channel <roomId>::$chat::$chatMessages. For example, if your room id is my-room then the messages channel will be my-room::$chat::$chatMessages.
+            "chatMessages"
+        case .typing:
+            "typingIndicators"
+        case .reactions:
+            "reactions"
+        case .presence, .occupancy:
+            // We’ll add these, with reference to the relevant spec points, as we implement these features
+            fatalError("Don’t know channel name suffix for room feature \(self)")
+        }
+    }
 }

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -40,7 +40,9 @@ internal protocol RoomLifecycleContributor: Identifiable, Sendable {
     func emitDiscontinuity(_ error: ARTErrorInfo) async
 }
 
-internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
+internal protocol RoomLifecycleManager: Sendable {}
+
+internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor>: RoomLifecycleManager {
     // MARK: - Constant properties
 
     private let logger: InternalLogger
@@ -583,7 +585,7 @@ internal actor RoomLifecycleManager<Contributor: RoomLifecycleContributor> {
 
     /// Executes a function that represents a room lifecycle operation.
     ///
-    /// - Note: Note that `RoomLifecycleManager` does not implement any sort of mutual exclusion mechanism that _enforces_ that one room lifecycle operation must wait for another (e.g. it is _not_ a queue); each operation needs to implement its own logic for whether it should proceed in the presence of other in-progress operations.
+    /// - Note: Note that `DefaultRoomLifecycleManager` does not implement any sort of mutual exclusion mechanism that _enforces_ that one room lifecycle operation must wait for another (e.g. it is _not_ a queue); each operation needs to implement its own logic for whether it should proceed in the presence of other in-progress operations.
     ///
     /// - Parameters:
     ///   - forcedOperationID: Forces the operation to have a given ID. In combination with the ``testsOnly_subscribeToOperationWaitEvents`` API, this allows tests to verify that one test-initiated operation is waiting for another test-initiated operation.

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -3,24 +3,6 @@ import Ably
 import Testing
 
 struct ChatAPITests {
-    // MARK: getChannel Tests
-
-    // @spec CHA-M1
-    @Test
-    func getChannel_returnsChannel() {
-        // Given
-        let realtime = MockRealtime.create(
-            channels: .init(channels: [.init(name: "basketball::$chat::$chatMessages")])
-        )
-        let chatAPI = ChatAPI(realtime: realtime)
-
-        // When
-        let channel = chatAPI.getChannel("basketball::$chat::$chatMessages")
-
-        // Then
-        #expect(channel.name == "basketball::$chat::$chatMessages")
-    }
-
     // MARK: sendMessage Tests
 
     // @spec CHA-M3c

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -153,7 +153,7 @@ struct DefaultRoomTests {
     // MARK: - Room status
 
     @Test
-    func current_startsAsInitialized() async throws {
+    func status_startsAsInitialized() async throws {
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
             MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"),

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -3,6 +3,25 @@ import Ably
 import Testing
 
 struct DefaultRoomTests {
+    // MARK: - Features
+
+    // @spec CHA-M1
+    @Test
+    func messagesChannelName() async throws {
+        // Given: a DefaultRoom instance
+        let channelsList = [
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success),
+        ]
+        let channels = MockChannels(channels: channelsList)
+        let realtime = MockRealtime.create(channels: channels)
+        let room = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger())
+
+        // Then
+        #expect(room.messages.channel.name == "basketball::$chat::$chatMessages")
+    }
+
     // MARK: - Attach
 
     @Test

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -7,7 +7,11 @@ struct DefaultRoomsTests {
     @Test
     func get_returnsRoomWithGivenID() async throws {
         // Given: an instance of DefaultRooms
-        let realtime = MockRealtime.create(channels: .init(channels: [.init(name: "basketball::$chat::$chatMessages")]))
+        let realtime = MockRealtime.create(channels: .init(channels: [
+            .init(name: "basketball::$chat::$chatMessages"),
+            .init(name: "basketball::$chat::$typingIndicators"),
+            .init(name: "basketball::$chat::$reactions"),
+        ]))
         let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger())
 
         // When: get(roomID:options:) is called
@@ -26,7 +30,11 @@ struct DefaultRoomsTests {
     @Test
     func get_returnsExistingRoomWithGivenID() async throws {
         // Given: an instance of DefaultRooms, on which get(roomID:options:) has already been called with a given ID
-        let realtime = MockRealtime.create(channels: .init(channels: [.init(name: "basketball::$chat::$chatMessages")]))
+        let realtime = MockRealtime.create(channels: .init(channels: [
+            .init(name: "basketball::$chat::$chatMessages"),
+            .init(name: "basketball::$chat::$typingIndicators"),
+            .init(name: "basketball::$chat::$reactions"),
+        ]))
         let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger())
 
         let roomID = "basketball"
@@ -44,7 +52,11 @@ struct DefaultRoomsTests {
     @Test
     func get_throwsErrorWhenOptionsDoNotMatch() async throws {
         // Given: an instance of DefaultRooms, on which get(roomID:options:) has already been called with a given ID and options
-        let realtime = MockRealtime.create(channels: .init(channels: [.init(name: "basketball::$chat::$chatMessages")]))
+        let realtime = MockRealtime.create(channels: .init(channels: [
+            .init(name: "basketball::$chat::$chatMessages"),
+            .init(name: "basketball::$chat::$typingIndicators"),
+            .init(name: "basketball::$chat::$reactions"),
+        ]))
         let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger())
 
         let roomID = "basketball"

--- a/Tests/AblyChatTests/Mocks/MockChannels.swift
+++ b/Tests/AblyChatTests/Mocks/MockChannels.swift
@@ -8,16 +8,12 @@ final class MockChannels: RealtimeChannelsProtocol, Sendable {
         self.channels = channels
     }
 
-    func get(_ name: String) -> MockRealtimeChannel {
+    func get(_ name: String, options _: ARTRealtimeChannelOptions) -> MockRealtimeChannel {
         guard let channel = (channels.first { $0.name == name }) else {
             fatalError("There is no mock channel with name \(name)")
         }
 
         return channel
-    }
-
-    func get(_ name: String, options _: ARTRealtimeChannelOptions) -> MockRealtimeChannel {
-        get(name)
     }
 
     func exists(_: String) -> Bool {


### PR DESCRIPTION
A few bits to prepare for #47; split into a separate PR so that the next one isn’t too large, and so that @umair-ably can incorporate the changes that affect features (namely, features receiving the channel from the `Room`) into his work. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced error handling for sending messages with stricter validation logic.
  - Introduced a method for generating channel names based on room IDs and features.
  - Added a new test for verifying the messages channel name in the `DefaultRoom`.

- **Bug Fixes**
  - Removed deprecated methods for channel retrieval, streamlining channel management.

- **Tests**
  - Updated test cases to reflect changes in channel handling and initialization processes.
  - Simplified test setup for `DefaultMessages` and `DefaultRoomLifecycleManager`.

These updates improve the robustness and clarity of the chat API, ensuring a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->