### PR TITLE
[ECO-4982] Implement room release

### DIFF
--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -20,8 +20,8 @@ public actor DefaultChatClient: ChatClient {
         self.realtime = realtime
         self.clientOptions = clientOptions ?? .init()
         logger = DefaultInternalLogger(logHandler: self.clientOptions.logHandler, logLevel: self.clientOptions.logLevel)
-        let roomLifecycleManagerFactory = DefaultRoomLifecycleManagerFactory()
-        rooms = DefaultRooms(realtime: realtime, clientOptions: self.clientOptions, logger: logger, lifecycleManagerFactory: roomLifecycleManagerFactory)
+        let roomFactory = DefaultRoomFactory()
+        rooms = DefaultRooms(realtime: realtime, clientOptions: self.clientOptions, logger: logger, roomFactory: roomFactory)
     }
 
     public nonisolated var connection: any Connection {

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -43,6 +43,7 @@ internal protocol RoomLifecycleContributor: Identifiable, Sendable {
 internal protocol RoomLifecycleManager: Sendable {
     func performAttachOperation() async throws
     func performDetachOperation() async throws
+    func performReleaseOperation() async
     var roomStatus: RoomStatus { get async }
     func onChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange>
 }
@@ -864,11 +865,19 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
 
     // MARK: - RELEASE operation
 
+    internal func performReleaseOperation() async {
+        await _performReleaseOperation(forcingOperationID: nil)
+    }
+
+    internal func performReleaseOperation(testsOnly_forcingOperationID forcedOperationID: UUID? = nil) async {
+        await _performReleaseOperation(forcingOperationID: forcedOperationID)
+    }
+
     /// Implements CHA-RL3’s RELEASE operation.
     ///
     /// - Parameters:
     ///   - forcedOperationID: Allows tests to force the operation to have a given ID. In combination with the ``testsOnly_subscribeToOperationWaitEvents`` API, this allows tests to verify that one test-initiated operation is waiting for another test-initiated operation.
-    internal func performReleaseOperation(testsOnly_forcingOperationID forcedOperationID: UUID? = nil) async {
+    internal func _performReleaseOperation(forcingOperationID forcedOperationID: UUID? = nil) async {
         await performAnOperation(forcingOperationID: forcedOperationID) { operationID in
             await bodyOfReleaseOperation(operationID: operationID)
         }

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -49,7 +49,22 @@ internal actor DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
         }
     }
 
-    internal func release(roomID _: String) async throws {
-        fatalError("Not yet implemented")
+    #if DEBUG
+        internal func testsOnly_hasExistingRoomWithID(_ roomID: String) -> Bool {
+            rooms[roomID] != nil
+        }
+    #endif
+
+    internal func release(roomID: String) async throws {
+        guard let room = rooms[roomID] else {
+            // TODO: what to do here? (https://github.com/ably/specification/pull/200/files#r1837154563) — Andy replied that it’s a no-op but that this is going to be specified in an upcoming PR when we make room-getting async
+            return
+        }
+
+        // CHA-RC1d
+        rooms.removeValue(forKey: roomID)
+
+        // CHA-RL1e
+        await room.release()
     }
 }

--- a/Tests/AblyChatTests/DefaultChatClientTests.swift
+++ b/Tests/AblyChatTests/DefaultChatClientTests.swift
@@ -22,7 +22,7 @@ struct DefaultChatClientTests {
         // Then: Its `rooms` property returns an instance of DefaultRooms with the same realtime client and client options
         let rooms = client.rooms
 
-        let defaultRooms = try #require(rooms as? DefaultRooms<DefaultRoomLifecycleManagerFactory>)
+        let defaultRooms = try #require(rooms as? DefaultRooms<DefaultRoomFactory>)
         #expect(defaultRooms.testsOnly_realtime === realtime)
         #expect(defaultRooms.clientOptions.isEqualForTestPurposes(options))
     }

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -92,6 +92,33 @@ struct DefaultRoomTests {
         #expect(await lifecycleManager.detachCallCount == 1)
     }
 
+    // MARK: - Release
+
+    // @spec CHA-RL3h - I haven’t explicitly tested that `performReleaseOperation()` happens _before_ releasing the channels (i.e. the “upon operation completion” part of the spec point), because it would require me to spend extra time on mock-writing which I can’t really afford to spend right now. I think we can live with it at least for the time being; I’m pretty sure there are other tests where the spec mentions or requires an order where I also haven’t tested the order.
+    @Test
+    func release() async throws {
+        // Given: a DefaultRoom instance
+        let channelsList = [
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+        ]
+        let channels = MockChannels(channels: channelsList)
+        let realtime = MockRealtime.create(channels: channels)
+
+        let lifecycleManager = MockRoomLifecycleManager()
+        let lifecycleManagerFactory = MockRoomLifecycleManagerFactory(manager: lifecycleManager)
+
+        let room = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger(), lifecycleManagerFactory: lifecycleManagerFactory)
+
+        // When: `release()` is called on the room
+        await room.release()
+
+        // Then: It:
+        // 1. calls `performReleaseOperation()` on the room lifecycle manager
+        // 2. calls `channels.release()` with the name of each of the features’ channels
+        #expect(await lifecycleManager.releaseCallCount == 1)
+        #expect(Set(channels.releaseArguments) == Set(channelsList.map(\.name)))
+    }
+
     // MARK: - Room status
 
     @Test

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -10,18 +10,23 @@ struct DefaultRoomsTests {
         let realtime = MockRealtime.create(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+        let options = RoomOptions()
+        let roomToReturn = MockRoom(options: options)
+        let roomFactory = MockRoomFactory(room: roomToReturn)
+        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
 
         // When: get(roomID:options:) is called
         let roomID = "basketball"
-        let options = RoomOptions()
         let room = try await rooms.get(roomID: roomID, options: options)
 
-        // Then: It returns a DefaultRoom instance that uses the same Realtime instance, with the given ID and options
-        let defaultRoom = try #require(room as? DefaultRoom<MockRoomLifecycleManagerFactory>)
-        #expect(defaultRoom.testsOnly_realtime === realtime)
-        #expect(defaultRoom.roomID == roomID)
-        #expect(defaultRoom.options == options)
+        // Then: It returns a room that uses the same Realtime instance, with the given ID and options
+        let mockRoom = try #require(room as? MockRoom)
+        #expect(mockRoom === roomToReturn)
+
+        let createRoomArguments = try #require(await roomFactory.createRoomArguments)
+        #expect(createRoomArguments.realtime === realtime)
+        #expect(createRoomArguments.roomID == roomID)
+        #expect(createRoomArguments.options == options)
     }
 
     // @spec CHA-RC1b
@@ -31,10 +36,11 @@ struct DefaultRoomsTests {
         let realtime = MockRealtime.create(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+        let options = RoomOptions()
+        let roomToReturn = MockRoom(options: options)
+        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let roomID = "basketball"
-        let options = RoomOptions()
         let firstRoom = try await rooms.get(roomID: roomID, options: options)
 
         // When: get(roomID:options:) is called with the same room ID
@@ -51,10 +57,11 @@ struct DefaultRoomsTests {
         let realtime = MockRealtime.create(channels: .init(channels: [
             .init(name: "basketball::$chat::$chatMessages"),
         ]))
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+        let options = RoomOptions()
+        let roomToReturn = MockRoom(options: options)
+        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let roomID = "basketball"
-        let options = RoomOptions()
         _ = try await rooms.get(roomID: roomID, options: options)
 
         // When: get(roomID:options:) is called with the same ID but different options

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -74,5 +74,16 @@ struct IntegrationTests {
         // (11) Check that we received a DETACHED status change as a result of detaching the room
         _ = try #require(await rxRoomStatusSubscription.first { $0.current == .detached })
         #expect(await rxRoom.status == .detached)
+
+        // (12) Release the room
+        try await rxClient.rooms.release(roomID: roomID)
+
+        // (13) Check that we received a RELEASED status change as a result of releasing the room
+        _ = try #require(await rxRoomStatusSubscription.first { $0.current == .released })
+        #expect(await rxRoom.status == .released)
+
+        // (14) Fetch the room we just released and check it’s a new object
+        let postReleaseRxRoom = try await rxClient.rooms.get(roomID: roomID, options: .init())
+        #expect(postReleaseRxRoom !== rxRoom)
     }
 }

--- a/Tests/AblyChatTests/Mocks/MockChannels.swift
+++ b/Tests/AblyChatTests/Mocks/MockChannels.swift
@@ -1,8 +1,11 @@
 import Ably
 import AblyChat
 
-final class MockChannels: RealtimeChannelsProtocol, Sendable {
+final class MockChannels: RealtimeChannelsProtocol, @unchecked Sendable {
     private let channels: [MockRealtimeChannel]
+    private let mutex = NSLock()
+    /// Access must be synchronized via ``mutex``.
+    private(set) var _releaseArguments: [String] = []
 
     init(channels: [MockRealtimeChannel]) {
         self.channels = channels
@@ -24,7 +27,17 @@ final class MockChannels: RealtimeChannelsProtocol, Sendable {
         fatalError("Not implemented")
     }
 
-    func release(_: String) {
-        fatalError("Not implemented")
+    func release(_ name: String) {
+        mutex.lock()
+        defer { mutex.unlock() }
+        _releaseArguments.append(name)
+    }
+
+    var releaseArguments: [String] {
+        let result: [String]
+        mutex.lock()
+        result = _releaseArguments
+        mutex.unlock()
+        return result
     }
 }

--- a/Tests/AblyChatTests/Mocks/MockRoom.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoom.swift
@@ -1,0 +1,49 @@
+@testable import AblyChat
+
+actor MockRoom: Room {
+    let options: RoomOptions
+
+    init(options: RoomOptions) {
+        self.options = options
+    }
+
+    nonisolated var roomID: String {
+        fatalError("Not implemented")
+    }
+
+    nonisolated var messages: any Messages {
+        fatalError("Not implemented")
+    }
+
+    nonisolated var presence: any Presence {
+        fatalError("Not implemented")
+    }
+
+    nonisolated var reactions: any RoomReactions {
+        fatalError("Not implemented")
+    }
+
+    nonisolated var typing: any Typing {
+        fatalError("Not implemented")
+    }
+
+    nonisolated var occupancy: any Occupancy {
+        fatalError("Not implemented")
+    }
+
+    var status: AblyChat.RoomStatus {
+        fatalError("Not implemented")
+    }
+
+    func onStatusChange(bufferingPolicy _: BufferingPolicy) async -> Subscription<RoomStatusChange> {
+        fatalError("Not implemented")
+    }
+
+    func attach() async throws {
+        fatalError("Not implemented")
+    }
+
+    func detach() async throws {
+        fatalError("Not implemented")
+    }
+}

--- a/Tests/AblyChatTests/Mocks/MockRoom.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoom.swift
@@ -1,10 +1,13 @@
 @testable import AblyChat
 
-actor MockRoom: Room {
+actor MockRoom: InternalRoom {
     let options: RoomOptions
+    private(set) var releaseCallCount = 0
+    let releaseImplementation: (@Sendable () async -> Void)?
 
-    init(options: RoomOptions) {
+    init(options: RoomOptions, releaseImplementation: (@Sendable () async -> Void)? = nil) {
         self.options = options
+        self.releaseImplementation = releaseImplementation
     }
 
     nonisolated var roomID: String {
@@ -45,5 +48,13 @@ actor MockRoom: Room {
 
     func detach() async throws {
         fatalError("Not implemented")
+    }
+
+    func release() async {
+        releaseCallCount += 1
+        guard let releaseImplementation else {
+            fatalError("releaseImplementation must be set before calling `release`")
+        }
+        await releaseImplementation()
     }
 }

--- a/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
@@ -1,0 +1,20 @@
+@testable import AblyChat
+
+actor MockRoomFactory: RoomFactory {
+    private let room: MockRoom?
+    private(set) var createRoomArguments: (realtime: RealtimeClient, chatAPI: ChatAPI, roomID: String, options: RoomOptions, logger: any InternalLogger)?
+
+    init(room: MockRoom? = nil) {
+        self.room = room
+    }
+
+    func createRoom(realtime: RealtimeClient, chatAPI: ChatAPI, roomID: String, options: RoomOptions, logger: any InternalLogger) async throws -> MockRoom {
+        createRoomArguments = (realtime: realtime, chatAPI: chatAPI, roomID: roomID, options: options, logger: logger)
+
+        guard let room else {
+            fatalError("MockRoomFactory.createRoom called, but the mock factory has not been set up with a room to return")
+        }
+
+        return room
+    }
+}

--- a/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
@@ -1,10 +1,14 @@
 @testable import AblyChat
 
 actor MockRoomFactory: RoomFactory {
-    private let room: MockRoom?
+    private var room: MockRoom?
     private(set) var createRoomArguments: (realtime: RealtimeClient, chatAPI: ChatAPI, roomID: String, options: RoomOptions, logger: any InternalLogger)?
 
     init(room: MockRoom? = nil) {
+        self.room = room
+    }
+
+    func setRoom(_ room: MockRoom) {
         self.room = room
     }
 

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
@@ -6,6 +6,7 @@ actor MockRoomLifecycleManager: RoomLifecycleManager {
     private(set) var attachCallCount = 0
     private let detachResult: Result<Void, ARTErrorInfo>?
     private(set) var detachCallCount = 0
+    private(set) var releaseCallCount = 0
     private let _roomStatus: RoomStatus?
     // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
     private var subscriptions: [Subscription<RoomStatusChange>] = []
@@ -30,6 +31,10 @@ actor MockRoomLifecycleManager: RoomLifecycleManager {
             fatalError("In order to call performDetachOperation, detachResult must be passed to the initializer")
         }
         try detachResult.get()
+    }
+
+    func performReleaseOperation() async {
+        releaseCallCount += 1
     }
 
     var roomStatus: RoomStatus {


### PR DESCRIPTION
**Note: This PR is based on top of #106; please review that one first.**

This implements the `DefaultRooms.release(roomID:)` method. See commit messages for more details.

Part of #47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `InternalRoom` protocol with enhanced room management capabilities.
  - Added a `release()` method for proper cleanup of rooms.
  - Implemented a `MockRoomFactory` for easier testing of room creation.

- **Bug Fixes**
  - Improved error handling in the room release process to prevent errors when rooms do not exist.

- **Tests**
  - Expanded test coverage for room functionalities, including new tests for the `release()` method and integration tests for room lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->