### PR TITLE
[ECO-4982] Implement `Messages` discontinuities (CHA-M7)

### DIFF
--- a/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
+++ b/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
@@ -1,8 +1,9 @@
 import Ably
 
-internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor {
+internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor, EmitsDiscontinuities {
     internal let channel: DefaultRoomLifecycleContributorChannel
     internal let feature: RoomFeature
+    private var discontinuitySubscriptions: [Subscription<ARTErrorInfo>] = []
 
     internal init(channel: DefaultRoomLifecycleContributorChannel, feature: RoomFeature) {
         self.channel = channel
@@ -11,8 +12,17 @@ internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor {
 
     // MARK: - Discontinuities
 
-    internal func emitDiscontinuity(_: ARTErrorInfo) {
-        // TODO: https://github.com/ably-labs/ably-chat-swift/issues/47
+    internal func emitDiscontinuity(_ error: ARTErrorInfo) {
+        for subscription in discontinuitySubscriptions {
+            subscription.emit(error)
+        }
+    }
+
+    internal func subscribeToDiscontinuities() -> Subscription<ARTErrorInfo> {
+        let subscription = Subscription<ARTErrorInfo>(bufferingPolicy: .unbounded)
+        // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
+        discontinuitySubscriptions.append(subscription)
+        return subscription
     }
 }
 

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -1,3 +1,5 @@
+import Ably
+
 /// The features offered by a chat room.
 internal enum RoomFeature {
     case messages
@@ -19,5 +21,24 @@ internal enum RoomFeature {
             // We’ll add these, with reference to the relevant spec points, as we implement these features
             fatalError("Don’t know channel name suffix for room feature \(self)")
         }
+    }
+}
+
+/// Provides all of the channel-related functionality that a room feature (e.g. an implementation of ``Messages``) needs.
+///
+/// This mishmash exists to give a room feature access to both:
+///
+/// - a `RealtimeChannelProtocol` object (this is the interface that our features are currently written against, as opposed to, say, `RoomLifecycleContributorChannel`)
+/// - the discontinuities emitted by the room lifecycle
+internal protocol FeatureChannel: Sendable, EmitsDiscontinuities {
+    var channel: RealtimeChannelProtocol { get }
+}
+
+internal struct DefaultFeatureChannel: FeatureChannel {
+    internal var channel: RealtimeChannelProtocol
+    internal var contributor: DefaultRoomLifecycleContributor
+
+    internal func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
+        await contributor.subscribeToDiscontinuities()
     }
 }

--- a/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
@@ -1,0 +1,24 @@
+import Ably
+@testable import AblyChat
+
+final actor MockFeatureChannel: FeatureChannel {
+    let channel: RealtimeChannelProtocol
+    // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
+    private var discontinuitySubscriptions: [Subscription<ARTErrorInfo>] = []
+
+    init(channel: RealtimeChannelProtocol) {
+        self.channel = channel
+    }
+
+    func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
+        let subscription = Subscription<ARTErrorInfo>(bufferingPolicy: .unbounded)
+        discontinuitySubscriptions.append(subscription)
+        return subscription
+    }
+
+    func emitDiscontinuity(_ discontinuity: ARTErrorInfo) {
+        for subscription in discontinuitySubscriptions {
+            subscription.emit(discontinuity)
+        }
+    }
+}


### PR DESCRIPTION
**Note: This PR is based on top of #107; please review that one first.**

Based on same spec as 8daa191.

Resolves #47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `FeatureChannel` protocol and `DefaultFeatureChannel` struct for enhanced channel functionality.
	- Updated `DefaultMessages` class to utilize `featureChannel`, improving message handling and subscription management.
	- Added `subscribeToDiscontinuities` method in `DefaultRoomLifecycleContributor` for better discontinuity event handling.

- **Bug Fixes**
	- Enhanced error handling in message subscriptions to ensure proper validation of incoming messages.

- **Tests**
	- Updated tests for `DefaultMessages` to reflect changes in initialization and added scenarios for testing discontinuities.
	- Introduced `MockFeatureChannel` for simulating channel behavior in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->