### PR TITLE
[ECO-4986] Implement the `RETRY` room lifecycle operation

### DIFF
--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -883,9 +883,9 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
                     // CHA-RL2h3: Retry until detach succeeds, with a pause before each attempt
                     while true {
                         do {
-                            logger.log(message: "Will attempt to detach non-failed contributor \(contributor) in 1s.", level: .info)
-                            // TODO: what's the correct wait time? (https://github.com/ably/specification/pull/200#discussion_r1763799223)
-                            try await clock.sleep(timeInterval: 1)
+                            let waitDuration = 0.25
+                            logger.log(message: "Will attempt to detach non-failed contributor \(contributor) in \(waitDuration)s.", level: .info)
+                            try await clock.sleep(timeInterval: waitDuration)
                             logger.log(message: "Detaching non-failed contributor \(contributor)", level: .info)
                             try await contributor.channel.detach()
                             break
@@ -968,11 +968,11 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
                     break
                 } catch {
                     // CHA-RL3f: Retry until detach succeeds, with a pause before each attempt
-                    logger.log(message: "Failed to detach contributor \(contributor), error \(error). Will retry in 1s.", level: .info)
+                    let waitDuration = 0.25
+                    logger.log(message: "Failed to detach contributor \(contributor), error \(error). Will retry in \(waitDuration)s.", level: .info)
                     // TODO: Make this not trap in the case where the Task is cancelled (as part of the broader https://github.com/ably-labs/ably-chat-swift/issues/29 for handling task cancellation)
-                    // TODO: what's the correct wait time? (https://github.com/ably/specification/pull/200#discussion_r1763822207)
                     // swiftlint:disable:next force_try
-                    try! await clock.sleep(timeInterval: 1)
+                    try! await clock.sleep(timeInterval: waitDuration)
                     // Loop repeats
                 }
             }

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -73,14 +73,16 @@ struct DefaultRoomLifecycleManagerTests {
         initialState: ARTRealtimeChannelState = .initialized,
         feature: RoomFeature = .messages, // Arbitrarily chosen, its value only matters in test cases where we check which error is thrown
         attachBehavior: MockRoomLifecycleContributorChannel.AttachOrDetachBehavior? = nil,
-        detachBehavior: MockRoomLifecycleContributorChannel.AttachOrDetachBehavior? = nil
+        detachBehavior: MockRoomLifecycleContributorChannel.AttachOrDetachBehavior? = nil,
+        subscribeToStateBehavior: MockRoomLifecycleContributorChannel.SubscribeToStateBehavior? = nil
     ) -> MockRoomLifecycleContributor {
         .init(
             feature: feature,
             channel: .init(
                 initialState: initialState,
                 attachBehavior: attachBehavior,
-                detachBehavior: detachBehavior
+                detachBehavior: detachBehavior,
+                subscribeToStateBehavior: subscribeToStateBehavior
             )
         )
     }

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -667,11 +667,11 @@ struct DefaultRoomLifecycleManagerTests {
         // When: `performDetachOperation()` is called on the manager
         try await manager.performDetachOperation()
 
-        // Then: It attempts to detach the channel 3 times, waiting 1s between each attempt, the room transitions from DETACHING to DETACHED with no status updates in between, and the call to `performDetachOperation()` succeeds
+        // Then: It attempts to detach the channel 3 times, waiting 250ms between each attempt, the room transitions from DETACHING to DETACHED with no status updates in between, and the call to `performDetachOperation()` succeeds
         #expect(await contributor.channel.detachCallCount == 3)
 
         // We use "did it call clock.sleep(…)?" as a good-enough proxy for the question "did it wait for the right amount of time at the right moment?"
-        #expect(await clock.sleepCallArguments == Array(repeating: 1, count: 2))
+        #expect(await clock.sleepCallArguments == Array(repeating: 0.25, count: 2))
 
         #expect(await asyncLetStatusChanges.map(\.current) == [.detaching, .detached])
     }
@@ -845,11 +845,11 @@ struct DefaultRoomLifecycleManagerTests {
         // Then: When `performReleaseOperation()` is called on the manager
         await manager.performReleaseOperation()
 
-        // It: calls `detach()` on the channel 3 times, with a 1s pause between each attempt, and the call to `performReleaseOperation` completes
+        // It: calls `detach()` on the channel 3 times, with a 0.25s pause between each attempt, and the call to `performReleaseOperation` completes
         #expect(await contributor.channel.detachCallCount == 3)
 
         // We use "did it call clock.sleep(…)?" as a good-enough proxy for the question "did it wait for the right amount of time at the right moment?"
-        #expect(await clock.sleepCallArguments == Array(repeating: 1, count: 2))
+        #expect(await clock.sleepCallArguments == Array(repeating: 0.25, count: 2))
     }
 
     // @specOneOf(2/2) CHA-RL3e - Tests that this spec point suppresses CHA-RL3f retries
@@ -870,13 +870,13 @@ struct DefaultRoomLifecycleManagerTests {
 
         // Then:
         // - it calls `detach()` precisely once on the contributor (that is, it does not retry)
-        // - it waits 1s (TODO: confirm my interpretation of CHA-RL3f, which is that the wait still happens, but is not followed by a retry; have asked in https://github.com/ably/specification/pull/200/files#r1765372854)
+        // - it waits 0.25s (TODO: confirm my interpretation of CHA-RL3f, which is that the wait still happens, but is not followed by a retry; have asked in https://github.com/ably/specification/pull/200/files#r1765372854)
         // - the room transitions to RELEASED
         // - the call to `performReleaseOperation()` completes
         #expect(await contributor.channel.detachCallCount == 1)
 
         // We use "did it call clock.sleep(…)?" as a good-enough proxy for the question "did it wait for the right amount of time at the right moment?"
-        #expect(await clock.sleepCallArguments == [1])
+        #expect(await clock.sleepCallArguments == [0.25])
 
         _ = await releasedStatusChange
 

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -169,7 +169,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: [
                 createContributor(
                     // Arbitrary, allows the ATTACH to eventually complete
-                    attachBehavior: .complete(.success),
+                    attachBehavior: .success,
                     // This allows us to prolong the execution of the DETACH triggered in (1)
                     detachBehavior: contributorDetachOperation.behavior
                 ),
@@ -235,7 +235,7 @@ struct DefaultRoomLifecycleManagerTests {
     @Test
     func attach_attachesAllContributors_andWhenTheyAllAttachSuccessfully_transitionsToAttached() async throws {
         // Given: A DefaultRoomLifecycleManager, all of whose contributors’ calls to `attach` succeed
-        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .complete(.success)) }
+        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .success) }
         let manager = await createManager(contributors: contributors)
 
         let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
@@ -257,7 +257,7 @@ struct DefaultRoomLifecycleManagerTests {
     @Test
     func attach_uponSuccess_emitsPendingDiscontinuityEvents() async throws {
         // Given: A DefaultRoomLifecycleManager, all of whose contributors’ calls to `attach` succeed
-        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .complete(.success)) }
+        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .success) }
         let pendingDiscontinuityEvents: [MockRoomLifecycleContributor.ID: [ARTErrorInfo]] = [
             contributors[1].id: [.init(domain: "SomeDomain", code: 123) /* arbitrary */ ],
             contributors[2].id: [.init(domain: "SomeDomain", code: 456) /* arbitrary */ ],
@@ -291,7 +291,7 @@ struct DefaultRoomLifecycleManagerTests {
     @Test
     func attach_uponSuccess_clearsTransientDisconnectTimeouts() async throws {
         // Given: A DefaultRoomLifecycleManager, all of whose contributors’ calls to `attach` succeed
-        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .complete(.success)) }
+        let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .success) }
         let manager = await createManager(
             forTestingWhatHappensWhenHasTransientDisconnectTimeoutForTheseContributorIDs: [contributors[1].id],
             contributors: contributors
@@ -315,7 +315,7 @@ struct DefaultRoomLifecycleManagerTests {
             if i == 1 {
                 createContributor(attachBehavior: .completeAndChangeState(.failure(contributorAttachError), newState: .suspended))
             } else {
-                createContributor(attachBehavior: .complete(.success))
+                createContributor(attachBehavior: .success)
             }
         }
 
@@ -363,9 +363,9 @@ struct DefaultRoomLifecycleManagerTests {
             } else {
                 createContributor(
                     feature: .occupancy, // arbitrary, just needs to be different to that used for the other contributor
-                    attachBehavior: .complete(.success),
+                    attachBehavior: .success,
                     // The room is going to try to detach per CHA-RL1h5, so even though that's not what this test is testing, we need a detachBehavior so the mock doesn’t blow up
-                    detachBehavior: .complete(.success)
+                    detachBehavior: .success
                 )
             }
         }
@@ -411,13 +411,13 @@ struct DefaultRoomLifecycleManagerTests {
         let contributors = [
             createContributor(
                 attachBehavior: .completeAndChangeState(.success, newState: .attached),
-                detachBehavior: .complete(.success)
+                detachBehavior: .success
             ),
             createContributor(
                 attachBehavior: .completeAndChangeState(.failure(.create(withCode: 123, message: "")), newState: .failed)
             ),
             createContributor(
-                detachBehavior: .complete(.success)
+                detachBehavior: .success
             ),
         ]
 
@@ -572,7 +572,7 @@ struct DefaultRoomLifecycleManagerTests {
     @Test
     func detach_detachesAllContributors_andWhenTheyAllDetachSuccessfully_transitionsToDetached() async throws {
         // Given: A DefaultRoomLifecycleManager, all of whose contributors’ calls to `detach` succeed
-        let contributors = (1 ... 3).map { _ in createContributor(detachBehavior: .complete(.success)) }
+        let contributors = (1 ... 3).map { _ in createContributor(detachBehavior: .success) }
         let manager = await createManager(contributors: contributors)
 
         let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
@@ -792,10 +792,10 @@ struct DefaultRoomLifecycleManagerTests {
         // - two in a non-FAILED state, and on whom calling `detach()` succeeds
         // - one in the FAILED state
         let contributors = [
-            createContributor(initialState: .attached /* arbitrary non-FAILED */, detachBehavior: .complete(.success)),
+            createContributor(initialState: .attached /* arbitrary non-FAILED */, detachBehavior: .success),
             // We put the one that will be skipped in the middle, to verify that the subsequent contributors don’t get skipped
-            createContributor(initialState: .failed, detachBehavior: .complete(.failure(.init(domain: "SomeDomain", code: 123) /* arbitrary error */ ))),
-            createContributor(initialState: .detached /* arbitrary non-FAILED */, detachBehavior: .complete(.success)),
+            createContributor(initialState: .failed, detachBehavior: .failure(.init(domain: "SomeDomain", code: 123) /* arbitrary error */ )),
+            createContributor(initialState: .detached /* arbitrary non-FAILED */, detachBehavior: .success),
         ]
 
         let manager = await createManager(contributors: contributors)

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
@@ -16,11 +16,13 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
 
     init(
         initialState: ARTRealtimeChannelState,
+        initialErrorReason: ARTErrorInfo?,
         attachBehavior: AttachOrDetachBehavior?,
         detachBehavior: AttachOrDetachBehavior?,
         subscribeToStateBehavior: SubscribeToStateBehavior?
     ) {
         state = initialState
+        errorReason = initialErrorReason
         self.attachBehavior = attachBehavior
         self.detachBehavior = detachBehavior
         self.subscribeToStateBehavior = subscribeToStateBehavior ?? .justAddSubscription


### PR DESCRIPTION
**Note: This PR is based on top of #115; please review that one first.**

Resolves #51. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced contributor management with new retry operation states for improved handling of transient failures.
	- Introduced a structured retry operation method to manage detachment and reattachment of contributors.

- **Bug Fixes**
	- Improved error handling during attachment and detachment processes, ensuring better state management.

- **Tests**
	- Expanded test coverage for retry operations and contributor management, validating the new functionality and error handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->