### PR TITLE
[ECO-4948] Spec complete for Presence + Occupancy (excluding room status behaviour)

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a296396707b7685153f4cf548f6281f483d562002fe11235f1fc3bb053be91d7",
+  "originHash" : "1ad2d7338668d15feccbf564582941161acd47349bfca8f34374e11c69677ae8",
   "pins" : [
     {
       "identity" : "ably-cocoa",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
         "branch" : "main",
-        "revision" : "4856ba6a423788902a6ef680793e7f404ceb4a51"
+        "revision" : "f7bff4b1c941b4c7b952b9224a33674e2302e19f"
       }
     },
     {

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -277,7 +277,7 @@ actor MockPresence: Presence {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,
-                data: ["foo": "bar"],
+                data: PresenceData(userCustomData: nil),
                 action: .present,
                 extras: nil,
                 updatedAt: Date()
@@ -285,11 +285,11 @@ actor MockPresence: Presence {
         }
     }
 
-    func get(params _: PresenceQuery?) async throws -> [PresenceMember] {
+    func get(params _: PresenceQuery) async throws -> [PresenceMember] {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,
-                data: ["foo": "bar"],
+                data: PresenceData(userCustomData: nil),
                 action: .present,
                 extras: nil,
                 updatedAt: Date()
@@ -301,20 +301,7 @@ actor MockPresence: Presence {
         fatalError("Not yet implemented")
     }
 
-    func enter() async throws {
-        for subscription in mockSubscriptions {
-            subscription.emit(
-                PresenceEvent(
-                    action: .enter,
-                    clientID: clientID,
-                    timestamp: Date(),
-                    data: nil
-                )
-            )
-        }
-    }
-
-    func enter(data: PresenceData) async throws {
+    func enter(data: PresenceData? = nil) async throws {
         for subscription in mockSubscriptions {
             subscription.emit(
                 PresenceEvent(
@@ -327,28 +314,20 @@ actor MockPresence: Presence {
         }
     }
 
-    func update() async throws {
-        fatalError("Not yet implemented")
-    }
-
-    func update(data _: PresenceData) async throws {
-        fatalError("Not yet implemented")
-    }
-
-    func leave() async throws {
+    func update(data: PresenceData? = nil) async throws {
         for subscription in mockSubscriptions {
             subscription.emit(
                 PresenceEvent(
-                    action: .leave,
+                    action: .update,
                     clientID: clientID,
                     timestamp: Date(),
-                    data: nil
+                    data: data
                 )
             )
         }
     }
 
-    func leave(data: PresenceData) async throws {
+    func leave(data: PresenceData? = nil) async throws {
         for subscription in mockSubscriptions {
             subscription.emit(
                 PresenceEvent(

--- a/Example/AblyChatExample/Mocks/MockRealtime.swift
+++ b/Example/AblyChatExample/Mocks/MockRealtime.swift
@@ -36,6 +36,10 @@ final class MockRealtime: NSObject, RealtimeClientProtocol, Sendable {
             fatalError("Not implemented")
         }
 
+        var presence: ARTRealtimePresenceProtocol {
+            fatalError("Not implemented")
+        }
+
         var errorReason: ARTErrorInfo? {
             fatalError("Not implemented")
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f00ee2e8c80adfe8d72deb089738cdb967aeae43e71837f90d99fc602728fe45",
+  "originHash" : "b6d25f160b01b473629481d68d4fe734b3981fcd87079531f784c2ade3afdc4d",
   "pins" : [
     {
       "identity" : "ably-cocoa",
@@ -7,7 +7,7 @@
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
         "branch" : "main",
-        "revision" : "4856ba6a423788902a6ef680793e7f404ceb4a51"
+        "revision" : "f7bff4b1c941b4c7b952b9224a33674e2302e19f"
       }
     },
     {

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -1,0 +1,56 @@
+import Ably
+
+internal final class DefaultOccupancy: Occupancy, EmitsDiscontinuities {
+    private let chatAPI: ChatAPI
+    private let roomID: String
+    private let logger: InternalLogger
+    public nonisolated let featureChannel: FeatureChannel
+
+    internal nonisolated var channel: any RealtimeChannelProtocol {
+        featureChannel.channel
+    }
+
+    internal init(featureChannel: FeatureChannel, chatAPI: ChatAPI, roomID: String, logger: InternalLogger) {
+        self.featureChannel = featureChannel
+        self.chatAPI = chatAPI
+        self.roomID = roomID
+        self.logger = logger
+    }
+
+    // (CHA-04a) Users may register a listener that receives occupancy events in realtime.
+    // (CHA-04c) When a regular occupancy event is received on the channel (a standard PubSub occupancy event per the docs), the SDK will convert it into occupancy event format and broadcast it to subscribers.
+    // (CHA-04d) If an invalid occupancy event is received on the channel, it shall be dropped.
+    internal func subscribe(bufferingPolicy: BufferingPolicy) async -> Subscription<OccupancyEvent> {
+        logger.log(message: "Subscribing to occupancy events", level: .debug)
+        let subscription = Subscription<OccupancyEvent>(bufferingPolicy: bufferingPolicy)
+        channel.subscribe(OccupancyEvents.meta.rawValue) { [logger] message in
+            logger.log(message: "Received occupancy message: \(message)", level: .debug)
+            guard let data = message.data as? [String: Any],
+                  let metrics = data["metrics"] as? [String: Any]
+            else {
+                let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data or metrics")
+                logger.log(message: "Error parsing occupancy message: \(error)", level: .error)
+                return // (CHA-04d) implies we don't throw an error
+            }
+
+            let connections = metrics["connections"] as? Int ?? 0
+            let presenceMembers = metrics["presenceMembers"] as? Int ?? 0
+
+            let occupancyEvent = OccupancyEvent(connections: connections, presenceMembers: presenceMembers)
+            logger.log(message: "Emitting occupancy event: \(occupancyEvent)", level: .debug)
+            subscription.emit(occupancyEvent)
+        }
+        return subscription
+    }
+
+    // (CHA-O3) Users can request an instantaneous occupancy check via the REST API. The request is detailed here (https://sdk.ably.com/builds/ably/specification/main/chat-features/#rest-occupancy-request), with the response format being a simple occupancy event
+    internal func get() async throws -> OccupancyEvent {
+        logger.log(message: "Getting occupancy for room: \(roomID)", level: .debug)
+        return try await chatAPI.getOccupancy(roomId: roomID)
+    }
+
+    // (CHA-O5) Users may subscribe to discontinuity events to know when there’s been a break in occupancy. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For occupancy, there shouldn’t need to be user action as most channels will send occupancy updates regularly as clients churn.
+    internal func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
+        await featureChannel.subscribeToDiscontinuities()
+    }
+}

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -1,0 +1,234 @@
+import Ably
+
+@MainActor
+internal final class DefaultPresence: Presence, EmitsDiscontinuities {
+    private let featureChannel: FeatureChannel
+    private let roomID: String
+    private let clientID: String
+    private let logger: InternalLogger
+
+    internal init(featureChannel: FeatureChannel, roomID: String, clientID: String, logger: InternalLogger) {
+        self.roomID = roomID
+        self.featureChannel = featureChannel
+        self.clientID = clientID
+        self.logger = logger
+    }
+
+    internal nonisolated var channel: any RealtimeChannelProtocol {
+        featureChannel.channel
+    }
+
+    // (CHA-PR6) It must be possible to retrieve all the @Members of the presence set. The behaviour depends on the current room status, as presence operations in a Realtime Client cause implicit attaches.
+    internal func get() async throws -> [PresenceMember] {
+        logger.log(message: "Getting presence", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.get { [processPresenceGet] members, error in
+                do {
+                    let presenceMembers = try processPresenceGet(members, error)
+                    continuation.resume(returning: presenceMembers)
+                } catch {
+                    continuation.resume(throwing: error)
+                    // processPresenceGet will log any errors
+                }
+            }
+        }
+    }
+
+    internal func get(params: PresenceQuery) async throws -> [PresenceMember] {
+        logger.log(message: "Getting presence with params: \(params)", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.get(params.asARTRealtimePresenceQuery()) { [processPresenceGet] members, error in
+                do {
+                    let presenceMembers = try processPresenceGet(members, error)
+                    continuation.resume(returning: presenceMembers)
+                } catch {
+                    continuation.resume(throwing: error)
+                    // processPresenceGet will log any errors
+                }
+            }
+        }
+    }
+
+    // (CHA-PR5) It must be possible to query if a given clientId is in the presence set.
+    internal func isUserPresent(clientID: String) async throws -> Bool {
+        logger.log(message: "Checking if user is present with clientID: \(clientID)", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.get(ARTRealtimePresenceQuery(clientId: clientID, connectionId: nil)) { [logger] members, error in
+                guard let members else {
+                    let error = error ?? ARTErrorInfo.createUnknownError()
+                    logger.log(message: error.message, level: .error)
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: !members.isEmpty)
+            }
+        }
+    }
+
+    // (CHA-PR3a) Users may choose to enter presence, optionally providing custom data to enter with. The overall presence data must retain the format specified in CHA-PR2.
+    internal func enter(data: PresenceData? = nil) async throws {
+        logger.log(message: "Entering presence", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.enterClient(clientID, data: data?.asQueryItems()) { [logger] error in
+                if let error {
+                    logger.log(message: "Error entering presence: \(error)", level: .error)
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    // (CHA-PR10a) Users may choose to update their presence data, optionally providing custom data to update with. The overall presence data must retain the format specified in CHA-PR2.
+    internal func update(data: PresenceData? = nil) async throws {
+        logger.log(message: "Updating presence", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.update(data?.asQueryItems()) { [logger] error in
+                if let error {
+                    logger.log(message: "Error updating presence: \(error)", level: .error)
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    // (CHA-PR4a) Users may choose to leave presence, which results in them being removed from the Realtime presence set.
+    internal func leave(data: PresenceData? = nil) async throws {
+        logger.log(message: "Leaving presence", level: .debug)
+        return try await withCheckedThrowingContinuation { continuation in
+            channel.presence.leave(data?.asQueryItems()) { [logger] error in
+                if let error {
+                    logger.log(message: "Error leaving presence: \(error)", level: .error)
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    // (CHA-PR7a) Users may provide a listener to subscribe to all presence events in a room.
+    // (CHA-PR7b) Users may provide a listener and a list of selected presence events, to subscribe to just those events in a room.
+    internal func subscribe(event: PresenceEventType) async -> Subscription<PresenceEvent> {
+        logger.log(message: "Subscribing to presence events", level: .debug)
+        let subscription = Subscription<PresenceEvent>(bufferingPolicy: .unbounded)
+        channel.presence.subscribe(event.toARTPresenceAction()) { [processPresenceSubscribe, logger] message in
+            logger.log(message: "Received presence message: \(message)", level: .debug)
+            Task {
+                // processPresenceSubscribe is logging so we don't need to log here
+                let presenceEvent = try processPresenceSubscribe(message, event)
+                subscription.emit(presenceEvent)
+            }
+        }
+        return subscription
+    }
+
+    internal func subscribe(events: [PresenceEventType]) async -> Subscription<PresenceEvent> {
+        logger.log(message: "Subscribing to presence events", level: .debug)
+        let subscription = Subscription<PresenceEvent>(bufferingPolicy: .unbounded)
+        for event in events {
+            channel.presence.subscribe(event.toARTPresenceAction()) { [processPresenceSubscribe, logger] message in
+                logger.log(message: "Received presence message: \(message)", level: .debug)
+                Task {
+                    let presenceEvent = try processPresenceSubscribe(message, event)
+                    subscription.emit(presenceEvent)
+                }
+            }
+        }
+        return subscription
+    }
+
+    // (CHA-PR8) Users may subscribe to discontinuity events to know when there’s been a break in presence. Their listener will be called when a discontinuity event is triggered from the room lifecycle. For presence, there shouldn’t need to be user action as the underlying core SDK will heal the presence set.
+    internal func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
+        await featureChannel.subscribeToDiscontinuities()
+    }
+
+    private func decodePresenceData(from data: Any?) -> PresenceData? {
+        guard let userData = data as? [String: Any] else {
+            return nil
+        }
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: userData, options: [])
+            let presenceData = try JSONDecoder().decode(PresenceData.self, from: jsonData)
+            return presenceData
+        } catch {
+            print("Failed to decode PresenceData: \(error)")
+            logger.log(message: "Failed to decode PresenceData: \(error)", level: .error)
+            return nil
+        }
+    }
+
+    private func processPresenceGet(members: [ARTPresenceMessage]?, error: ARTErrorInfo?) throws -> [PresenceMember] {
+        guard let members else {
+            let error = error ?? ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data or text")
+            logger.log(message: error.message, level: .error)
+            throw error
+        }
+        let presenceMembers = try members.map { member in
+            guard let data = member.data as? [String: Any] else {
+                let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without data")
+                logger.log(message: error.message, level: .error)
+                throw error
+            }
+
+            guard let clientID = member.clientId else {
+                let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without clientId")
+                logger.log(message: error.message, level: .error)
+                throw error
+            }
+
+            guard let timestamp = member.timestamp else {
+                let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without timestamp")
+                logger.log(message: error.message, level: .error)
+                throw error
+            }
+
+            let userCustomData = decodePresenceData(from: data)
+
+            // Seems like we want to just forward on `extras` from the cocoa SDK but that is an `ARTJsonCompatible` type which is not `Sendable`... currently just converting this to a `Sendable` type (`String`) until we know what to do with this.
+            let extras = member.extras?.toJSONString()
+
+            let presenceMember = PresenceMember(
+                clientID: clientID,
+                data: userCustomData ?? .init(),
+                action: PresenceMember.Action(from: member.action),
+                extras: extras,
+                updatedAt: timestamp
+            )
+
+            logger.log(message: "Returning presence member: \(presenceMember)", level: .debug)
+            return presenceMember
+        }
+        return presenceMembers
+    }
+
+    private func processPresenceSubscribe(_ message: ARTPresenceMessage, for event: PresenceEventType) throws -> PresenceEvent {
+        guard let clientID = message.clientId else {
+            let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without clientId")
+            logger.log(message: error.message, level: .error)
+            throw error
+        }
+
+        guard let timestamp = message.timestamp else {
+            let error = ARTErrorInfo.create(withCode: 50000, status: 500, message: "Received incoming message without timestamp")
+            logger.log(message: error.message, level: .error)
+            throw error
+        }
+
+        let userCustomDataDecoded = decodePresenceData(from: message.data)
+
+        let presenceEvent = PresenceEvent(
+            action: event,
+            clientID: clientID,
+            timestamp: timestamp,
+            data: userCustomDataDecoded ?? .init()
+        )
+
+        logger.log(message: "Returning presence event: \(presenceEvent)", level: .debug)
+        return presenceEvent
+    }
+}

--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -24,13 +24,20 @@ public protocol RealtimeChannelProtocol: ARTRealtimeChannelProtocol, Sendable {}
 internal extension RealtimeClientProtocol {
     // Function to get the channel with merged options
     func getChannel(_ name: String, opts: ARTRealtimeChannelOptions? = nil) -> any RealtimeChannelProtocol {
-        // Merge opts and defaultChannelOptions
-        let resolvedOptions = opts ?? ARTRealtimeChannelOptions()
+        // Create a new instance of ARTRealtimeChannelOptions if opts is nil
+        let resolvedOptions = ARTRealtimeChannelOptions()
 
-        // Merge params if available, using defaultChannelOptions as fallback
-        resolvedOptions.params = opts?.params?.merging(
+        // Merge params if available, using opts first, then defaultChannelOptions as fallback
+        resolvedOptions.params = (opts?.params ?? [:]).merging(
             defaultChannelOptions.params ?? [:]
         ) { _, new in new }
+
+        // Apply other options from `opts` if necessary
+        if let customOpts = opts {
+            resolvedOptions.modes = customOpts.modes
+            resolvedOptions.cipher = customOpts.cipher
+            resolvedOptions.attachOnSubscribe = customOpts.attachOnSubscribe
+        }
 
         // Return the resolved channel
         return channels.get(name, options: resolvedOptions)

--- a/Sources/AblyChat/Events.swift
+++ b/Sources/AblyChat/Events.swift
@@ -5,3 +5,7 @@ internal enum MessageEvent: String {
 internal enum RoomReactionEvents: String {
     case reaction = "roomReaction"
 }
+
+internal enum OccupancyEvents: String {
+    case meta = "[meta]occupancy"
+}

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -6,6 +6,7 @@ public protocol Occupancy: AnyObject, Sendable, EmitsDiscontinuities {
     var channel: RealtimeChannelProtocol { get }
 }
 
+// (CHA-O2) The occupancy event format is shown here (https://sdk.ably.com/builds/ably/specification/main/chat-features/#chat-structs-occupancy-event)
 public struct OccupancyEvent: Sendable, Encodable, Decodable {
     public var connections: Int
     public var presenceMembers: Int

--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -14,13 +14,15 @@ internal enum RoomFeature {
 
     private var channelNameSuffix: String {
         switch self {
-        case .messages:
+        case .messages, .presence, .occupancy:
             // (CHA-M1) Chat messages for a Room are sent on a corresponding realtime channel <roomId>::$chat::$chatMessages. For example, if your room id is my-room then the messages channel will be my-room::$chat::$chatMessages.
+            // (CHA-PR1) Presence for a Room is exposed on the realtime channel used for chat messages, in the format <roomId>::$chat::$chatMessages. For example, if your room id is my-room then the presence channel will be my-room::$chat::$chatMessages.
+            // (CHA-O1) Occupancy for a room is exposed on the realtime channel used for chat messages, in the format <roomId>::$chat::$chatMessages. For example, if your room id is my-room then the presence channel will be my-room::$chat::$chatMessages.
             "chatMessages"
         case .reactions:
             // (CHA-ER1) Reactions for a Room are sent on a corresponding realtime channel <roomId>::$chat::$reactions. For example, if your room id is my-room then the reactions channel will be my-room::$chat::$reactions.
             "reactions"
-        case .typing, .presence, .occupancy:
+        case .typing:
             // We’ll add these, with reference to the relevant spec points, as we implement these features
             fatalError("Don’t know channel name suffix for room feature \(self)")
         }

--- a/Sources/AblyChat/RoomOptions.swift
+++ b/Sources/AblyChat/RoomOptions.swift
@@ -14,6 +14,9 @@ public struct RoomOptions: Sendable, Equatable {
     }
 }
 
+// (CHA-PR9) Users may configure their presence options via the RoomOptions provided at room configuration time.
+// (CHA-PR9a) Setting enter to false prevents the user from entering presence by means of the ChannelMode on the underlying realtime channel. Entering presence will result in an error. The default is true.
+// (CHA-PR9b) Setting subscribe to false prevents the user from subscribing to presence by means of the ChannelMode on the underlying realtime channel. This does not prevent them from receiving their own presence messages, but they will not receive them from others. The default is true.
 public struct PresenceOptions: Sendable, Equatable {
     public var enter = true
     public var subscribe = true

--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -2,6 +2,10 @@ import Ably
 import AblyChat
 
 final class MockRealtimeChannel: NSObject, RealtimeChannelProtocol {
+    var presence: ARTRealtimePresenceProtocol {
+        fatalError("Not implemented")
+    }
+
     private let attachSerial: String?
     private let channelSerial: String?
     private let _name: String?


### PR DESCRIPTION
- There seemed to be redundant duplication in the Presence protocol... I've just streamlined this by having an optional `Data` param where possible
- Excluding spec points relating to room status behaviour, this is spec complete for Presence and Occupancy. I'll add the  room status behaviour in a follow up PR once that's ready 
- Added integration tests

Will add unit tests as part of a separate PR/[ticket](https://github.com/ably-labs/ably-chat-swift/issues/114)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced presence and occupancy management in the chat application.
	- Introduced `DefaultOccupancy` and `DefaultPresence` classes for improved event handling.
	- Added support for real-time presence updates and occupancy checks.
  
- **Documentation**
	- Improved comments in `RoomOptions` and `PresenceOptions` to clarify configuration details.

- **Tests**
	- Expanded integration tests to cover occupancy and presence functionalities, ensuring expected behavior during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->