### PR TITLE
[ECO-5114] Provide mechanism for waiting to be able to perform presence operations

### DIFF
--- a/Sources/AblyChat/RoomFeature.swift
+++ b/Sources/AblyChat/RoomFeature.swift
@@ -31,19 +31,38 @@ internal enum RoomFeature {
 
 /// Provides all of the channel-related functionality that a room feature (e.g. an implementation of ``Messages``) needs.
 ///
-/// This mishmash exists to give a room feature access to both:
+/// This mishmash exists to give a room feature access to:
 ///
 /// - a `RealtimeChannelProtocol` object (this is the interface that our features are currently written against, as opposed to, say, `RoomLifecycleContributorChannel`)
 /// - the discontinuities emitted by the room lifecycle
+/// - the presence-readiness wait mechanism supplied by the room lifecycle
 internal protocol FeatureChannel: Sendable, EmitsDiscontinuities {
     var channel: RealtimeChannelProtocol { get }
+
+    /// Waits until we can perform presence operations on the contributors of this room without triggering an implicit attach.
+    ///
+    /// Implements the checks described by CHA-PR3d, CHA-PR3e, CHA-PR3f, and CHA-PR3g (and similar ones described by other functionality that performs contributor presence operations). Namely:
+    ///
+    /// - CHA-PR3d, CHA-PR10d, CHA-PR6c, CHA-T2c: If the room is in the ATTACHING status, it waits for the current ATTACH to complete and then returns. If the current ATTACH fails, then it re-throws that operation’s error.
+    /// - CHA-PR3e, CHA-PR11e, CHA-PR6d, CHA-T2d: If the room is in the ATTACHED status, it returns immediately.
+    /// - CHA-PR3f, CHA-PR11f, CHA-PR6e, CHA-T2e: If the room is in the DETACHED status, it throws an `ARTErrorInfo` derived from ``ChatError.presenceOperationRequiresRoomAttach(feature:)``.
+    /// - // CHA-PR3g, CHA-PR11g, CHA-PR6f, CHA-T2f: If the room is in any other status, it throws an `ARTErrorInfo` derived from ``ChatError.presenceOperationDisallowedForCurrentRoomStatus(feature:)``.
+    ///
+    /// - Parameters:
+    ///   - requester: The room feature that wishes to perform a presence operation. This is only used for customising the message of the thrown error.
+    func waitToBeAbleToPerformPresenceOperations(requestedByFeature requester: RoomFeature) async throws(ARTErrorInfo)
 }
 
 internal struct DefaultFeatureChannel: FeatureChannel {
     internal var channel: RealtimeChannelProtocol
     internal var contributor: DefaultRoomLifecycleContributor
+    internal var roomLifecycleManager: RoomLifecycleManager
 
     internal func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
         await contributor.subscribeToDiscontinuities()
+    }
+
+    internal func waitToBeAbleToPerformPresenceOperations(requestedByFeature requester: RoomFeature) async throws(ARTErrorInfo) {
+        try await roomLifecycleManager.waitToBeAbleToPerformPresenceOperations(requestedByFeature: requester)
     }
 }

--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -604,6 +604,7 @@ internal actor DefaultRoomLifecycleManager<Contributor: RoomLifecycleContributor
             logger.log(message: "Operation \(waitingOperationID) completed waiting for result of operation \(waitedOperationID), which completed successfully", level: .debug)
         } catch {
             logger.log(message: "Operation \(waitingOperationID) completed waiting for result of operation \(waitedOperationID), which threw error \(error)", level: .debug)
+            throw error
         }
     }
 

--- a/Tests/AblyChatTests/Helpers/Helpers.swift
+++ b/Tests/AblyChatTests/Helpers/Helpers.swift
@@ -2,9 +2,9 @@ import Ably
 @testable import AblyChat
 
 /**
- Tests whether a given optional `Error` is an `ARTErrorInfo` in the chat error domain with a given code and cause.
+ Tests whether a given optional `Error` is an `ARTErrorInfo` in the chat error domain with a given code and cause. Can optionally pass a message and it will check that it matches.
  */
-func isChatError(_ maybeError: (any Error)?, withCode code: AblyChat.ErrorCode, cause: ARTErrorInfo? = nil) -> Bool {
+func isChatError(_ maybeError: (any Error)?, withCode code: AblyChat.ErrorCode, cause: ARTErrorInfo? = nil, message: String? = nil) -> Bool {
     guard let ablyError = maybeError as? ARTErrorInfo else {
         return false
     }
@@ -13,4 +13,11 @@ func isChatError(_ maybeError: (any Error)?, withCode code: AblyChat.ErrorCode, 
         && ablyError.code == code.rawValue
         && ablyError.statusCode == code.statusCode
         && ablyError.cause == cause
+        && {
+            guard let message else {
+                return true
+            }
+
+            return ablyError.message == message
+        }()
 }

--- a/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockFeatureChannel.swift
@@ -5,9 +5,14 @@ final actor MockFeatureChannel: FeatureChannel {
     let channel: RealtimeChannelProtocol
     // TODO: clean up old subscriptions (https://github.com/ably-labs/ably-chat-swift/issues/36)
     private var discontinuitySubscriptions: [Subscription<ARTErrorInfo>] = []
+    private let resultOfWaitToBeAbleToPerformPresenceOperations: Result<Void, ARTErrorInfo>?
 
-    init(channel: RealtimeChannelProtocol) {
+    init(
+        channel: RealtimeChannelProtocol,
+        resultOfWaitToBeAblePerformPresenceOperations: Result<Void, ARTErrorInfo>? = nil
+    ) {
         self.channel = channel
+        resultOfWaitToBeAbleToPerformPresenceOperations = resultOfWaitToBeAblePerformPresenceOperations
     }
 
     func subscribeToDiscontinuities() async -> Subscription<ARTErrorInfo> {
@@ -20,5 +25,13 @@ final actor MockFeatureChannel: FeatureChannel {
         for subscription in discontinuitySubscriptions {
             subscription.emit(discontinuity)
         }
+    }
+
+    func waitToBeAbleToPerformPresenceOperations(requestedByFeature _: RoomFeature) async throws(ARTErrorInfo) {
+        guard let resultOfWaitToBeAbleToPerformPresenceOperations else {
+            fatalError("resultOfWaitToBeAblePerformPresenceOperations must be set before waitToBeAbleToPerformPresenceOperations is called")
+        }
+
+        try resultOfWaitToBeAbleToPerformPresenceOperations.get()
     }
 }

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleContributorChannel.swift
@@ -39,7 +39,7 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
 
     enum AttachOrDetachBehavior {
         /// Receives an argument indicating how many times (including the current call) the method for which this is providing a mock implementation has been called.
-        case fromFunction(@Sendable (Int) async -> AttachOrDetachResult)
+        case fromFunction(@Sendable (Int) async -> AttachOrDetachBehavior)
         case complete(AttachOrDetachResult)
         case completeAndChangeState(AttachOrDetachResult, newState: ARTRealtimeChannelState)
 
@@ -76,7 +76,9 @@ final actor MockRoomLifecycleContributorChannel: RoomLifecycleContributorChannel
         let result: AttachOrDetachResult
         switch behavior {
         case let .fromFunction(function):
-            result = await function(callCount)
+            let behavior = await function(callCount)
+            try await performBehavior(behavior, callCount: callCount)
+            return
         case let .complete(completeResult):
             result = completeResult
         case let .completeAndChangeState(completeResult, newState):

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
@@ -55,4 +55,8 @@ actor MockRoomLifecycleManager: RoomLifecycleManager {
             subscription.emit(statusChange)
         }
     }
+
+    func waitToBeAbleToPerformPresenceOperations(requestedByFeature _: RoomFeature) async throws(ARTErrorInfo) {
+        fatalError("Not implemented")
+    }
 }


### PR DESCRIPTION
**Note: This PR is based on top of #118; please review that one first.**

This should unblock @umair-ably’s implementation of presence and typing indicators. See commit messages for more details.

Resolves #112.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error handling cases for better clarity in error messages.
	- Added methods to manage presence operations based on room status.
	- Enhanced lifecycle management for feature channels.
	- Updated `Helpers` function to validate error messages.
	- Expanded `MockFeatureChannel` to handle presence operation readiness.

- **Bug Fixes**
	- Improved error handling and state management in the Room Lifecycle Manager.

- **Tests**
	- Added new test cases for presence operation behaviors and lifecycle management.
	- Updated existing tests to reflect changes in method signatures and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->