### PR TITLE
[ECO-4985] Trigger the RETRY operation where spec says to

### DIFF
--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -218,7 +218,7 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
     // MARK: - Room status
 
     internal func onStatusChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange> {
-        await lifecycleManager.onChange(bufferingPolicy: bufferingPolicy)
+        await lifecycleManager.onRoomStatusChange(bufferingPolicy: bufferingPolicy)
     }
 
     internal var status: RoomStatus {

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -1727,7 +1727,7 @@ struct DefaultRoomLifecycleManagerTests {
                 contributorThatWillEmitStateChange.id,
                 contributors[1].id,
             ],
-            contributors: [contributorThatWillEmitStateChange]
+            contributors: contributors
         )
 
         let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -183,7 +183,7 @@ struct DefaultRoomLifecycleManagerTests {
         let detachOperationID = UUID()
         let attachOperationID = UUID()
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         // Wait for the manager to enter DETACHING; this our sign that the DETACH operation triggered in (1) has started
         async let detachingStatusChange = statusChangeSubscription.first { $0.current == .detaching }
 
@@ -219,7 +219,7 @@ struct DefaultRoomLifecycleManagerTests {
         let contributorAttachOperation = SignallableChannelOperation()
 
         let manager = await createManager(contributors: [createContributor(attachBehavior: contributorAttachOperation.behavior)])
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let statusChange = statusChangeSubscription.first { _ in true }
 
         // When: `performAttachOperation()` is called on the lifecycle manager
@@ -242,7 +242,7 @@ struct DefaultRoomLifecycleManagerTests {
         let contributors = (1 ... 3).map { _ in createContributor(attachBehavior: .success) }
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let attachedStatusChange = statusChangeSubscription.first { $0.current == .attached }
 
         // When: `performAttachOperation()` is called on the lifecycle manager
@@ -325,7 +325,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeSuspendedStatusChange = statusChangeSubscription.suspendedElements().first { _ in true }
 
         // When: `performAttachOperation()` is called on the lifecycle manager
@@ -376,7 +376,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeFailedStatusChange = statusChangeSubscription.failedElements().first { _ in true }
 
         // When: `performAttachOperation()` is called on the lifecycle manager
@@ -556,7 +556,7 @@ struct DefaultRoomLifecycleManagerTests {
             forTestingWhatHappensWhenHasTransientDisconnectTimeoutForTheseContributorIDs: [contributor.id],
             contributors: [contributor]
         )
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let statusChange = statusChangeSubscription.first { _ in true }
 
         // When: `performDetachOperation()` is called on the lifecycle manager
@@ -579,7 +579,7 @@ struct DefaultRoomLifecycleManagerTests {
         let contributors = (1 ... 3).map { _ in createContributor(detachBehavior: .success) }
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let detachedStatusChange = statusChangeSubscription.first { $0.current == .detached }
 
         // When: `performDetachOperation()` is called on the lifecycle manager
@@ -616,7 +616,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeFailedStatusChange = statusChangeSubscription.failedElements().first { _ in true }
 
         // When: `performDetachOperation()` is called on the lifecycle manager
@@ -663,7 +663,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: [contributor], clock: clock)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let asyncLetStatusChanges = Array(statusChangeSubscription.prefix(2))
 
         // When: `performDetachOperation()` is called on the manager
@@ -701,7 +701,7 @@ struct DefaultRoomLifecycleManagerTests {
         let contributor = createContributor()
         let manager = await createManager(forTestingWhatHappensWhenCurrentlyIn: .detached, contributors: [contributor])
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let statusChange = statusChangeSubscription.first { _ in true }
 
         // When: `performReleaseOperation()` is called on the lifecycle manager
@@ -727,7 +727,7 @@ struct DefaultRoomLifecycleManagerTests {
         let firstReleaseOperationID = UUID()
         let secondReleaseOperationID = UUID()
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         // Wait for the manager to enter RELEASING; this our sign that the DETACH operation triggered in (1) has started
         async let releasingStatusChange = statusChangeSubscription.first { $0.current == .releasing }
 
@@ -772,7 +772,7 @@ struct DefaultRoomLifecycleManagerTests {
             forTestingWhatHappensWhenHasTransientDisconnectTimeoutForTheseContributorIDs: [contributor.id],
             contributors: [contributor]
         )
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let statusChange = statusChangeSubscription.first { _ in true }
 
         // When: `performReleaseOperation()` is called on the lifecycle manager
@@ -804,7 +804,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let releasedStatusChange = statusChangeSubscription.first { $0.current == .released }
 
         // When: `performReleaseOperation()` is called on the lifecycle manager
@@ -864,7 +864,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: [contributor], clock: clock)
 
-        let statusChangeSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let releasedStatusChange = statusChangeSubscription.first { $0.current == .released }
 
         // When: `performReleaseOperation()` is called on the lifecycle manager
@@ -1001,7 +1001,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         let manager = await createManager(contributors: contributors)
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeFailedStatusChange = roomStatusSubscription.failedElements().first { _ in true }
 
         // When: `performRetryOperation(triggeredByContributor:errorForSuspendedStatus:)` is called on the manager, triggered by the contributor at index 0
@@ -1089,7 +1089,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeFailedStatusChange = roomStatusSubscription.failedElements().first { _ in true }
 
         // When: `performRetryOperation(triggeredByContributor:errorForSuspendedStatus:)` is called on the manager, triggered by the aforementioned contributor
@@ -1160,7 +1160,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeAttachingStatusChange = roomStatusSubscription.attachingElements().first { _ in true }
 
         // When: `performRetryOperation(triggeredByContributor:errorForSuspendedStatus:)` is called on the manager, triggered by the aforementioned contributor
@@ -1206,7 +1206,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let attachedStatusChange = roomStatusSubscription.first { $0.current == .attached }
 
         // When: `performRetryOperation(triggeredByContributor:errorForSuspendedStatus:)` is called on the manager
@@ -1254,7 +1254,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let failedStatusChange = roomStatusSubscription.failedElements().first { _ in true }
 
         // When: `performRetryOperation(triggeredByContributor:errorForSuspendedStatus:)` is called on the manager
@@ -1376,7 +1376,7 @@ struct DefaultRoomLifecycleManagerTests {
         try await manager.performAttachOperation()
 
         // This is to put the manager into the DETACHING state, to satisfy "with a room lifecycle operation in progress"
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let _ = manager.performDetachOperation()
         _ = await roomStatusSubscription.first { $0.current == .detaching }
 
@@ -1451,7 +1451,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let failedStatusChange = roomStatusSubscription.failedElements().first { _ in true }
 
         // When: A contributor emits an FAILED event
@@ -1547,7 +1547,7 @@ struct DefaultRoomLifecycleManagerTests {
 
         // and When: This transient disconnect timeout completes
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeRoomAttachingStatusChange = roomStatusSubscription.attachingElements().first { _ in true }
 
         sleepOperation.complete()
@@ -1659,7 +1659,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: contributors
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeAttachedRoomStatusChange = roomStatusSubscription.first { $0.current == .attached }
 
         // When: A contributor emits a state change to ATTACHED
@@ -1730,7 +1730,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: [contributorThatWillEmitStateChange]
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeSuspendedRoomStatusChange = roomStatusSubscription.suspendedElements().first { _ in true }
 
         // When: A contributor emits a state change to SUSPENDED
@@ -1775,7 +1775,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: [contributor]
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
 
         let attachOperationID = UUID()
         async let _ = manager.performAttachOperation(testsOnly_forcingOperationID: attachOperationID)
@@ -1813,7 +1813,7 @@ struct DefaultRoomLifecycleManagerTests {
             contributors: [contributor]
         )
 
-        let roomStatusSubscription = await manager.onChange(bufferingPolicy: .unbounded)
+        let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
 
         let attachOperationID = UUID()
         async let _ = manager.performAttachOperation(testsOnly_forcingOperationID: attachOperationID)

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -310,23 +310,51 @@ struct DefaultRoomLifecycleManagerTests {
 
     // @spec CHA-RL1h2
     // @specOneOf(1/2) CHA-RL1h1 - tests that an error gets thrown when channel attach fails due to entering SUSPENDED (TODO: but I don’t yet fully understand the meaning of CHA-RL1h1; outstanding question https://github.com/ably/specification/pull/200/files#r1765476610)
-    // @specPartial CHA-RL1h3 - Have tested the failure of the operation and the error that’s thrown. Have not yet implemented the "enter the recovery loop" (TODO: https://github.com/ably-labs/ably-chat-swift/issues/50)
+    // @spec CHA-RL1h3
     @Test
-    func attach_whenContributorFailsToAttachAndEntersSuspended_transitionsToSuspended() async throws {
+    func attach_whenContributorFailsToAttachAndEntersSuspended_transitionsToSuspendedAndPerformsRetryOperation() async throws {
         // Given: A DefaultRoomLifecycleManager, one of whose contributors’ call to `attach` fails causing it to enter the SUSPENDED status
         let contributorAttachError = ARTErrorInfo(domain: "SomeDomain", code: 123)
+        var nonSuspendedContributorsDetachOperations: [SignallableChannelOperation] = []
         let contributors = (1 ... 3).map { i in
             if i == 1 {
-                createContributor(attachBehavior: .completeAndChangeState(.failure(contributorAttachError), newState: .suspended))
+                return createContributor(
+                    attachBehavior: .fromFunction { callCount in
+                        if callCount == 1 {
+                            .completeAndChangeState(.failure(contributorAttachError), newState: .suspended) // The behaviour described above
+                        } else {
+                            .success // So the CHA-RL5f RETRY attachment cycle succeeds
+                        }
+                    },
+
+                    // This is so that the RETRY operation’s wait-to-become-ATTACHED succeeds
+                    subscribeToStateBehavior: .addSubscriptionAndEmitStateChange(
+                        .init(
+                            current: .attached,
+                            previous: .detached, // arbitrary
+                            event: .attached,
+                            reason: .createUnknownError() // Not related to this test, just to avoid a crash in CHA-RL4b1 handling of this state change
+                        )
+                    )
+                )
             } else {
-                createContributor(attachBehavior: .success)
+                // These contributors will be detached by the RETRY operation; we want to be able to delay their completion (and hence delay the RETRY operation’s transition from SUSPENDED to DETACHED) until we have been able to verify that the room’s status is SUSPENDED
+                let detachOperation = SignallableChannelOperation()
+                nonSuspendedContributorsDetachOperations.append(detachOperation)
+
+                return createContributor(
+                    attachBehavior: .success, // So the CHA-RL5f RETRY attachment cycle succeeds
+                    detachBehavior: detachOperation.behavior
+                )
             }
         }
 
         let manager = await createManager(contributors: contributors)
 
-        let statusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
-        async let maybeSuspendedStatusChange = statusChangeSubscription.suspendedElements().first { _ in true }
+        let roomStatusChangeSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
+        async let maybeSuspendedRoomStatusChange = roomStatusChangeSubscription.suspendedElements().first { _ in true }
+
+        let managerStatusChangeSubscription = await manager.testsOnly_onStatusChange()
 
         // When: `performAttachOperation()` is called on the lifecycle manager
         async let roomAttachResult: Void = manager.performAttachOperation()
@@ -336,7 +364,7 @@ struct DefaultRoomLifecycleManagerTests {
         // 1. the room status transitions to SUSPENDED, with the status change’s `error` having the AttachmentFailed code corresponding to the feature of the failed contributor, `cause` equal to the error thrown by the contributor `attach` call
         // 2. the manager’s `error` is set to this same error
         // 3. the room attach operation fails with this same error
-        let suspendedStatusChange = try #require(await maybeSuspendedStatusChange)
+        let suspendedRoomStatusChange = try #require(await maybeSuspendedRoomStatusChange)
 
         #expect(await manager.roomStatus.isSuspended)
 
@@ -347,9 +375,41 @@ struct DefaultRoomLifecycleManagerTests {
             roomAttachError = error
         }
 
-        for error in await [suspendedStatusChange.error, manager.roomStatus.error, roomAttachError] {
+        for error in await [suspendedRoomStatusChange.error, manager.roomStatus.error, roomAttachError] {
             #expect(isChatError(error, withCode: .messagesAttachmentFailed, cause: contributorAttachError))
         }
+
+        // and:
+        // 4. The manager asynchronously performs a RETRY operation, triggered by the contributor that entered SUSPENDED
+
+        // Allow the RETRY operation’s contributor detaches to complete
+        for detachOperation in nonSuspendedContributorsDetachOperations {
+            detachOperation.complete(behavior: .success) // So the CHA-RL5a RETRY detachment cycle succeeds
+        }
+
+        // Wait for the RETRY to finish
+        let retryOperationTask = try #require(await managerStatusChangeSubscription.compactMap { statusChange in
+            if case let .suspendedAwaitingStartOfRetryOperation(retryOperationTask, _) = statusChange.current {
+                return retryOperationTask
+            }
+            return nil
+        }
+        .first { _ in
+            true
+        })
+
+        await retryOperationTask.value
+
+        // We confirm that a RETRY happened by checking for its expected side effects:
+        #expect(await contributors[0].channel.detachCallCount == 0) // RETRY doesn’t touch this since it’s the one that triggered the RETRY
+        #expect(await contributors[1].channel.detachCallCount == 1) // From the CHA-RL5a RETRY detachment cycle
+        #expect(await contributors[2].channel.detachCallCount == 1) // From the CHA-RL5a RETRY detachment cycle
+
+        #expect(await contributors[0].channel.attachCallCount == 2) // From the ATTACH operation and the CHA-RL5f RETRY attachment cycle
+        #expect(await contributors[1].channel.attachCallCount == 1) // From the CHA-RL5f RETRY attachment cycle
+        #expect(await contributors[2].channel.attachCallCount == 1) // From the CHA-RL5f RETRY attachment cycle
+
+        _ = try #require(await roomStatusChangeSubscription.first { $0.current == .attached }) // Room status changes to ATTACHED
     }
 
     // @specOneOf(2/2) CHA-RL1h1 - tests that an error gets thrown when channel attach fails due to entering FAILED (TODO: but I don’t yet fully understand the meaning of CHA-RL1h1; outstanding question https://github.com/ably/specification/pull/200/files#r1765476610))
@@ -1710,16 +1770,38 @@ struct DefaultRoomLifecycleManagerTests {
         #expect(await manager.roomStatus == initialManagerStatus.toRoomStatus)
     }
 
-    // @specPartial CHA-RL4b9 - Haven’t implemented "the room enters the RETRY loop"; TODO do this (https://github.com/ably-labs/ably-chat-swift/issues/51)
+    // @spec CHA-RL4b9
     @Test
     func contributorSuspendedEvent_withNoOperationInProgress() async throws {
         // Given: A DefaultRoomLifecycleManager with no lifecycle operation in progress
-        let contributorThatWillEmitStateChange = createContributor()
+        let contributorThatWillEmitStateChange = createContributor(
+            attachBehavior: .success, // So the CHA-RL5f RETRY attachment cycle succeeds
+
+            // This is so that the RETRY operation’s wait-to-become-ATTACHED succeeds
+            subscribeToStateBehavior: .addSubscriptionAndEmitStateChange(
+                .init(
+                    current: .attached,
+                    previous: .detached, // arbitrary
+                    event: .attached,
+                    reason: .createUnknownError() // Not related to this test, just to avoid a crash in CHA-RL4b1 handling of this state change
+                )
+            )
+        )
+
+        var nonSuspendedContributorsDetachOperations: [SignallableChannelOperation] = []
         let contributors = [
             contributorThatWillEmitStateChange,
-            createContributor(),
-            createContributor(),
-        ]
+        ] + (1 ... 2).map { _ in
+            // These contributors will be detached by the RETRY operation; we want to be able to delay their completion (and hence delay the RETRY operation’s transition from SUSPENDED to DETACHED) until we have been able to verify that the room’s status is SUSPENDED
+            let detachOperation = SignallableChannelOperation()
+            nonSuspendedContributorsDetachOperations.append(detachOperation)
+
+            return createContributor(
+                attachBehavior: .success, // So the CHA-RL5f RETRY attachment cycle succeeds
+                detachBehavior: detachOperation.behavior
+            )
+        }
+
         let manager = await createManager(
             forTestingWhatHappensWhenCurrentlyIn: .initialized, // case arbitrary, just care that no operation is in progress
             // Give 2 of the 3 contributors a transient disconnect timeout, so we can test that _all_ such timeouts get cleared (as the spec point specifies), not just those for the SUSPENDED contributor
@@ -1732,6 +1814,8 @@ struct DefaultRoomLifecycleManagerTests {
 
         let roomStatusSubscription = await manager.onRoomStatusChange(bufferingPolicy: .unbounded)
         async let maybeSuspendedRoomStatusChange = roomStatusSubscription.suspendedElements().first { _ in true }
+
+        let managerStatusChangeSubscription = await manager.testsOnly_onStatusChange()
 
         // When: A contributor emits a state change to SUSPENDED
         let contributorStateChangeReason = ARTErrorInfo(domain: "SomeDomain", code: 123) // arbitrary
@@ -1748,14 +1832,46 @@ struct DefaultRoomLifecycleManagerTests {
         }
 
         // Then:
-        // - The room transitions to SUSPENDED, and this status change has error equal to the contributor state change’s `reason`
-        // - All transient disconnect timeouts are cancelled
+        // 1. The room transitions to SUSPENDED, and this status change has error equal to the contributor state change’s `reason`
+        // 2. All transient disconnect timeouts are cancelled
         let suspendedRoomStatusChange = try #require(await maybeSuspendedRoomStatusChange)
         #expect(suspendedRoomStatusChange.error === contributorStateChangeReason)
 
         #expect(await manager.roomStatus == .suspended(error: contributorStateChangeReason))
 
         #expect(await !manager.testsOnly_hasTransientDisconnectTimeoutForAnyContributor)
+
+        // and:
+        // 3. The manager performs a RETRY operation, triggered by the contributor that entered SUSPENDED
+
+        // Allow the RETRY operation’s contributor detaches to complete
+        for detachOperation in nonSuspendedContributorsDetachOperations {
+            detachOperation.complete(behavior: .success) // So the CHA-RL5a RETRY detachment cycle succeeds
+        }
+
+        // Wait for the RETRY to finish
+        let retryOperationTask = try #require(await managerStatusChangeSubscription.compactMap { statusChange in
+            if case let .suspendedAwaitingStartOfRetryOperation(retryOperationTask, _) = statusChange.current {
+                return retryOperationTask
+            }
+            return nil
+        }
+        .first { _ in
+            true
+        })
+
+        await retryOperationTask.value
+
+        // We confirm that a RETRY happened by checking for its expected side effects:
+        #expect(await contributors[0].channel.detachCallCount == 0) // RETRY doesn’t touch this since it’s the one that triggered the RETRY
+        #expect(await contributors[1].channel.detachCallCount == 1) // From the CHA-RL5a RETRY detachment cycle
+        #expect(await contributors[2].channel.detachCallCount == 1) // From the CHA-RL5a RETRY detachment cycle
+
+        #expect(await contributors[0].channel.attachCallCount == 1) // From the CHA-RL5f RETRY attachment cycle
+        #expect(await contributors[1].channel.attachCallCount == 1) // From the CHA-RL5f RETRY attachment cycle
+        #expect(await contributors[2].channel.attachCallCount == 1) // From the CHA-RL5f RETRY attachment cycle
+
+        _ = try #require(await roomStatusSubscription.first { $0.current == .attached }) // Room status changes to ATTACHED
     }
 
     // MARK: - Waiting to be able to perform presence operations

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
@@ -44,7 +44,7 @@ actor MockRoomLifecycleManager: RoomLifecycleManager {
         return roomStatus
     }
 
-    func onChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange> {
+    func onRoomStatusChange(bufferingPolicy: BufferingPolicy) async -> Subscription<RoomStatusChange> {
         let subscription = Subscription<RoomStatusChange>(bufferingPolicy: bufferingPolicy)
         subscriptions.append(subscription)
         return subscription


### PR DESCRIPTION
This is a re-opening of the already-approved-but-accidentally-merged-at-wrong-time #120. Will merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `typing` property in the room protocol, paving the way for future typing functionality.
  
- **Improvements**
	- Updated method names for clarity, enhancing the understanding of room status changes.
	- Added a new `OperationKind` enum to better manage scheduled operations.
  
- **Bug Fixes**
	- Enhanced error handling for room status changes and transient disconnects in tests.
  
- **Tests**
	- Updated test cases to reflect the new method names and improved logic for room status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->