### PR TITLE
[ECO-5904] Disable implicit attach

### DIFF
--- a/Sources/AblyChat/Dependencies.swift
+++ b/Sources/AblyChat/Dependencies.swift
@@ -25,18 +25,21 @@ public protocol RealtimeChannelProtocol: ARTRealtimeChannelProtocol, Sendable {}
 internal struct RealtimeChannelOptions {
     internal var modes: ARTChannelMode
     internal var params: [String: String]?
+    internal var attachOnSubscribe: Bool
 
     internal init() {
         // Get our default values from ably-cocoa
         let artRealtimeChannelOptions = ARTRealtimeChannelOptions()
         modes = artRealtimeChannelOptions.modes
         params = artRealtimeChannelOptions.params
+        attachOnSubscribe = artRealtimeChannelOptions.attachOnSubscribe
     }
 
     internal var toARTRealtimeChannelOptions: ARTRealtimeChannelOptions {
         let result = ARTRealtimeChannelOptions()
         result.modes = modes
         result.params = params
+        result.attachOnSubscribe = attachOnSubscribe
         return result
     }
 }
@@ -52,6 +55,9 @@ internal extension RealtimeClientProtocol {
         ) { _, new
             in new
         }
+
+        // CHA-GP2a
+        resolvedOptions.attachOnSubscribe = false
 
         return channels.get(name, options: resolvedOptions.toARTRealtimeChannelOptions)
     }

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -138,7 +138,7 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
             RoomFeature.presence,
             RoomFeature.occupancy,
         ].map { feature in
-            let channelOptions = ARTRealtimeChannelOptions()
+            var channelOptions = RealtimeChannelOptions()
 
             // channel setup for presence and occupancy
             if feature == .presence {

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -8,8 +8,4 @@ internal let version = "0.1.0"
 
 internal let channelOptionsAgentString = "chat-ios/\(version)"
 
-internal var defaultChannelOptions: ARTRealtimeChannelOptions {
-    let options = ARTRealtimeChannelOptions()
-    options.params = ["agent": channelOptionsAgentString]
-    return options
-}
+internal let defaultChannelParams = ["agent": channelOptionsAgentString]

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -4,13 +4,13 @@ import Ably
 
 // Update this when you release a new version
 // Version information
-public let version = "0.1.0"
+internal let version = "0.1.0"
 
 // Channel options agent string
-public let channelOptionsAgentString = "chat-ios/\(version)"
+internal let channelOptionsAgentString = "chat-ios/\(version)"
 
 // Default channel options
-public var defaultChannelOptions: ARTRealtimeChannelOptions {
+internal var defaultChannelOptions: ARTRealtimeChannelOptions {
     let options = ARTRealtimeChannelOptions()
     options.params = ["agent": channelOptionsAgentString]
     return options

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -6,10 +6,8 @@ import Ably
 // Version information
 internal let version = "0.1.0"
 
-// Channel options agent string
 internal let channelOptionsAgentString = "chat-ios/\(version)"
 
-// Default channel options
 internal var defaultChannelOptions: ARTRealtimeChannelOptions {
     let options = ARTRealtimeChannelOptions()
     options.params = ["agent": channelOptionsAgentString]

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -3,6 +3,26 @@ import Ably
 import Testing
 
 struct DefaultRoomTests {
+    // MARK: - Fetching channels
+
+    // @spec CHA-GP2a
+    @Test
+    func disablesImplicitAttach() async throws {
+        // Given: A DefaultRoom instance
+        let channelsList = [
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success),
+        ]
+        let channels = MockChannels(channels: channelsList)
+        let realtime = MockRealtime.create(channels: channels)
+        _ = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        // Then: When it fetches a channel, it does so with the `attachOnSubscribe` channel option set to false
+        let channelsGetArguments = channels.getArguments
+        #expect(!channelsGetArguments.isEmpty)
+        #expect(channelsGetArguments.allSatisfy { $0.options.attachOnSubscribe == false })
+    }
+
     // MARK: - Features
 
     // @spec CHA-M1


### PR DESCRIPTION
Implements spec point CHA-GP2a.

Resolves #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `RealtimeChannelOptions` for enhanced channel configuration.
	- Updated `Room` protocol to utilize the new channel options structure.

- **Bug Fixes**
	- Improved error handling for accessing disabled features in the `Room` protocol.

- **Tests**
	- Added a new test to ensure that implicit attachment is disabled when fetching channels.

- **Chores**
	- Updated visibility of certain constants to internal within the `Version` module for better encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->