### PR TITLE
[ECO-5128] Fetch each channel once

### DIFF
--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -142,7 +142,6 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
 
             // channel setup for presence and occupancy
             if feature == .presence {
-                let channelOptions = ARTRealtimeChannelOptions()
                 let presenceOptions = roomOptions.presence
 
                 if presenceOptions?.enter ?? false {

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -131,7 +131,7 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
         internal var contributor: DefaultRoomLifecycleContributor
     }
 
-    private static func createFeatureChannelPartialDependencies(roomID: String, roomOptions: RoomOptions, realtime: RealtimeClient) -> [RoomFeature: FeatureChannelPartialDependencies] {
+    private static func createFeatureChannelPartialDependencies(roomID: String, roomOptions _: RoomOptions, realtime: RealtimeClient) -> [RoomFeature: FeatureChannelPartialDependencies] {
         .init(uniqueKeysWithValues: [
             RoomFeature.messages,
             RoomFeature.reactions,
@@ -142,15 +142,18 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
 
             // channel setup for presence and occupancy
             if feature == .presence {
-                let presenceOptions = roomOptions.presence
+                // TODO: Restore this code once we understand weird Realtime behaviour and spec points (https://github.com/ably-labs/ably-chat-swift/issues/133)
+                /*
+                 let presenceOptions = roomOptions.presence
 
-                if presenceOptions?.enter ?? false {
-                    channelOptions.modes.insert(.presence)
-                }
+                 if presenceOptions?.enter ?? false {
+                     channelOptions.modes.insert(.presence)
+                 }
 
-                if presenceOptions?.subscribe ?? false {
-                    channelOptions.modes.insert(.presenceSubscribe)
-                }
+                 if presenceOptions?.subscribe ?? false {
+                     channelOptions.modes.insert(.presenceSubscribe)
+                 }
+                 */
             } else if feature == .occupancy {
                 channelOptions.params = ["occupancy": "metrics"]
             }


### PR DESCRIPTION
Implements CHA-RC3a. See commit messages for more details.

Resolves #132.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced channel creation with a new method for managing multiple feature channels.
	- Improved error handling for presence, reactions, typing, and occupancy features.

- **Bug Fixes**
	- Added tests to ensure channels are fetched correctly and only once.

- **Documentation**
	- Updated comments and TODOs for future improvements in the `Room` protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->