### PR TITLE
[ECO-5098] Only fetch channels and create contributors for enabled room features

### DIFF
--- a/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
+++ b/Sources/AblyChat/DefaultRoomLifecycleContributor.swift
@@ -1,8 +1,8 @@
 import Ably
 
 internal actor DefaultRoomLifecycleContributor: RoomLifecycleContributor, EmitsDiscontinuities {
-    internal let channel: DefaultRoomLifecycleContributorChannel
-    internal let feature: RoomFeature
+    internal nonisolated let channel: DefaultRoomLifecycleContributorChannel
+    internal nonisolated let feature: RoomFeature
     private var discontinuitySubscriptions: [Subscription<ARTErrorInfo>] = []
 
     internal init(channel: DefaultRoomLifecycleContributorChannel, feature: RoomFeature) {

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -74,6 +74,51 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
 
     private let logger: InternalLogger
 
+    private enum RoomFeatureWithOptions {
+        case messages
+        case presence(PresenceOptions)
+        case typing(TypingOptions)
+        case reactions(RoomReactionsOptions)
+        case occupancy(OccupancyOptions)
+
+        var toRoomFeature: RoomFeature {
+            switch self {
+            case .messages:
+                .messages
+            case .presence:
+                .presence
+            case .typing:
+                .typing
+            case .reactions:
+                .reactions
+            case .occupancy:
+                .occupancy
+            }
+        }
+
+        static func fromRoomOptions(_ roomOptions: RoomOptions) -> [Self] {
+            var result: [Self] = [.messages]
+
+            if let presenceOptions = roomOptions.presence {
+                result.append(.presence(presenceOptions))
+            }
+
+            if let typingOptions = roomOptions.typing {
+                result.append(.typing(typingOptions))
+            }
+
+            if let reactionsOptions = roomOptions.reactions {
+                result.append(.reactions(reactionsOptions))
+            }
+
+            if let occupancyOptions = roomOptions.occupancy {
+                result.append(.occupancy(occupancyOptions))
+            }
+
+            return result
+        }
+    }
+
     internal init(realtime: RealtimeClient, chatAPI: ChatAPI, roomID: String, options: RoomOptions, logger: InternalLogger, lifecycleManagerFactory: LifecycleManagerFactory) async throws {
         self.realtime = realtime
         self.roomID = roomID
@@ -85,7 +130,9 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
             throw ARTErrorInfo.create(withCode: 40000, message: "Ensure your Realtime instance is initialized with a clientId.")
         }
 
-        let featureChannelPartialDependencies = Self.createFeatureChannelPartialDependencies(roomID: roomID, roomOptions: options, realtime: realtime)
+        let featuresWithOptions = RoomFeatureWithOptions.fromRoomOptions(options)
+
+        let featureChannelPartialDependencies = Self.createFeatureChannelPartialDependencies(roomID: roomID, featuresWithOptions: featuresWithOptions, realtime: realtime)
         channels = featureChannelPartialDependencies.mapValues(\.channel)
         let contributors = featureChannelPartialDependencies.values.map(\.contributor)
 
@@ -96,8 +143,6 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
 
         let featureChannels = Self.createFeatureChannels(partialDependencies: featureChannelPartialDependencies, lifecycleManager: lifecycleManager)
 
-        // TODO: Address force unwrapping of `channels` within feature initialisation below: https://github.com/ably-labs/ably-chat-swift/issues/105
-
         messages = await DefaultMessages(
             featureChannel: featureChannels[.messages]!,
             chatAPI: chatAPI,
@@ -106,34 +151,50 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
             logger: logger
         )
 
-        _reactions = options.reactions != nil ? await DefaultRoomReactions(
-            featureChannel: featureChannels[.reactions]!,
-            clientID: clientId,
-            roomID: roomID,
-            logger: logger
-        ) : nil
+        _reactions = if let featureChannel = featureChannels[.reactions] {
+            await DefaultRoomReactions(
+                featureChannel: featureChannel,
+                clientID: clientId,
+                roomID: roomID,
+                logger: logger
+            )
+        } else {
+            nil
+        }
 
-        _presence = options.presence != nil ? await DefaultPresence(
-            featureChannel: featureChannels[.presence]!,
-            roomID: roomID,
-            clientID: clientId,
-            logger: logger
-        ) : nil
+        _presence = if let featureChannel = featureChannels[.presence] {
+            await DefaultPresence(
+                featureChannel: featureChannel,
+                roomID: roomID,
+                clientID: clientId,
+                logger: logger
+            )
+        } else {
+            nil
+        }
 
-        _occupancy = options.occupancy != nil ? DefaultOccupancy(
-            featureChannel: featureChannels[.occupancy]!,
-            chatAPI: chatAPI,
-            roomID: roomID,
-            logger: logger
-        ) : nil
+        _occupancy = if let featureChannel = featureChannels[.occupancy] {
+            DefaultOccupancy(
+                featureChannel: featureChannel,
+                chatAPI: chatAPI,
+                roomID: roomID,
+                logger: logger
+            )
+        } else {
+            nil
+        }
 
-        _typing = options.typing != nil ? DefaultTyping(
-            featureChannel: featureChannels[.typing]!,
-            roomID: roomID,
-            clientID: clientId,
-            logger: logger,
-            timeout: options.typing?.timeout ?? 5
-        ) : nil
+        _typing = if let featureChannel = featureChannels[.typing] {
+            DefaultTyping(
+                featureChannel: featureChannel,
+                roomID: roomID,
+                clientID: clientId,
+                logger: logger,
+                timeout: options.typing?.timeout ?? 5
+            )
+        } else {
+            nil
+        }
     }
 
     private struct FeatureChannelPartialDependencies {
@@ -142,32 +203,30 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
     }
 
     /// The returned dictionary is guaranteed to have an entry for each element of `features`.
-    private static func createChannelsForFeatures(_ features: [RoomFeature], roomID: String, roomOptions _: RoomOptions, realtime: RealtimeClient) -> [RoomFeature: RealtimeChannelProtocol] {
+    private static func createChannelsForFeaturesWithOptions(_ featuresWithOptions: [RoomFeatureWithOptions], roomID: String, realtime: RealtimeClient) -> [RoomFeature: RealtimeChannelProtocol] {
         // CHA-RC3a
 
         // Multiple features can share a realtime channel. We fetch each realtime channel exactly once, merging the channel options for the various features that use this channel.
 
-        let featuresGroupedByChannelName = Dictionary(grouping: features) { $0.channelNameForRoomID(roomID) }
+        let featuresGroupedByChannelName = Dictionary(grouping: featuresWithOptions) { $0.toRoomFeature.channelNameForRoomID(roomID) }
 
         let pairsOfFeatureAndChannel = featuresGroupedByChannelName.flatMap { channelName, features in
             var channelOptions = RealtimeChannelOptions()
 
             // channel setup for presence and occupancy
             for feature in features {
-                if feature == .presence {
+                if case /* let */ .presence /* (presenceOptions) */ = feature {
                     // TODO: Restore this code once we understand weird Realtime behaviour and spec points (https://github.com/ably-labs/ably-chat-swift/issues/133)
                     /*
-                     let presenceOptions = roomOptions.presence
-
-                     if presenceOptions?.enter ?? false {
+                     if presenceOptions.enter {
                          channelOptions.modes.insert(.presence)
                      }
 
-                     if presenceOptions?.subscribe ?? false {
+                     if presenceOptions.subscribe {
                          channelOptions.modes.insert(.presenceSubscribe)
                      }
                      */
-                } else if feature == .occupancy {
+                } else if case .occupancy = feature {
                     var params: [String: String] = channelOptions.params ?? [:]
                     params["occupancy"] = "metrics"
                     channelOptions.params = params
@@ -175,21 +234,14 @@ internal actor DefaultRoom<LifecycleManagerFactory: RoomLifecycleManagerFactory>
             }
 
             let channel = realtime.getChannel(channelName, opts: channelOptions)
-            return features.map { ($0, channel) }
+            return features.map { ($0.toRoomFeature, channel) }
         }
 
         return Dictionary(uniqueKeysWithValues: pairsOfFeatureAndChannel)
     }
 
-    private static func createFeatureChannelPartialDependencies(roomID: String, roomOptions: RoomOptions, realtime: RealtimeClient) -> [RoomFeature: FeatureChannelPartialDependencies] {
-        let features: [RoomFeature] = [
-            .messages,
-            .reactions,
-            .presence,
-            .occupancy,
-            .typing,
-        ]
-        let channelsByFeature = createChannelsForFeatures(features, roomID: roomID, roomOptions: roomOptions, realtime: realtime)
+    private static func createFeatureChannelPartialDependencies(roomID: String, featuresWithOptions: [RoomFeatureWithOptions], realtime: RealtimeClient) -> [RoomFeature: FeatureChannelPartialDependencies] {
+        let channelsByFeature = createChannelsForFeaturesWithOptions(featuresWithOptions, roomID: roomID, realtime: realtime)
 
         return .init(uniqueKeysWithValues: channelsByFeature.map { feature, channel in
             let contributor = DefaultRoomLifecycleContributor(channel: .init(underlyingChannel: channel), feature: feature)

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -10,9 +10,9 @@ struct DefaultRoomTests {
     func disablesImplicitAttach() async throws {
         // Given: A DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"),
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -29,9 +29,9 @@ struct DefaultRoomTests {
     func fetchesEachChannelOnce() async throws {
         // Given: A DefaultRoom instance, configured to use presence and occupancy
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"),
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -55,9 +55,9 @@ struct DefaultRoomTests {
     func messagesChannelName() async throws {
         // Given: a DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -78,9 +78,9 @@ struct DefaultRoomTests {
     func attach(managerAttachResult: Result<Void, ARTErrorInfo>) async throws {
         // Given: a DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", attachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -116,9 +116,9 @@ struct DefaultRoomTests {
     func detach(managerDetachResult: Result<Void, ARTErrorInfo>) async throws {
         // Given: a DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -151,8 +151,8 @@ struct DefaultRoomTests {
         // Given: a DefaultRoom instance
         let channelsList = [
             MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -178,9 +178,9 @@ struct DefaultRoomTests {
     func status() async throws {
         // Given: a DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)
@@ -200,9 +200,9 @@ struct DefaultRoomTests {
     func onStatusChange() async throws {
         // Given: a DefaultRoom instance
         let channelsList = [
-            MockRealtimeChannel(name: "basketball::$chat::$chatMessages", detachResult: .success),
-            MockRealtimeChannel(name: "basketball::$chat::$reactions", attachResult: .success), // required as DefaultRoom attaches reactions implicitly for now
-            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators", attachResult: .success), // required as DefaultRoom attaches typingIndicators implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"), // required as DefaultRoom attaches reactions implicitly for now
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"), // required as DefaultRoom attaches typingIndicators implicitly for now
         ]
         let channels = MockChannels(channels: channelsList)
         let realtime = MockRealtime.create(channels: channels)

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -67,6 +67,39 @@ struct DefaultRoomTests {
         #expect(room.messages.channel.name == "basketball::$chat::$chatMessages")
     }
 
+    // TODO: Only create contributors for features user has enabled (https://github.com/ably-labs/ably-chat-swift/issues/105)
+    // TODO: Only fetch channel for features user has enabled (https://github.com/ably-labs/ably-chat-swift/issues/105)
+    @Test
+    func fetchesChannelAndCreatesLifecycleContributorForEachFeature() async throws {
+        // Given: a DefaultRoom instance
+        let channelsList = [
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"),
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"),
+        ]
+        let channels = MockChannels(channels: channelsList)
+        let realtime = MockRealtime.create(channels: channels)
+        let lifecycleManagerFactory = MockRoomLifecycleManagerFactory()
+        _ = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: .init(), logger: TestLogger(), lifecycleManagerFactory: lifecycleManagerFactory)
+
+        // Then: It:
+        // - fetches the channel that corresponds to each feature
+        // - initializes the RoomLifecycleManager with a contributor for each feature
+        let lifecycleManagerCreationArguments = try #require(await lifecycleManagerFactory.createManagerArguments.first)
+        let expectedFeatures: [RoomFeature] = [.messages, .occupancy, .reactions, .presence, .typing]
+        #expect(lifecycleManagerCreationArguments.contributors.count == expectedFeatures.count)
+        #expect(Set(lifecycleManagerCreationArguments.contributors.map(\.feature)) == Set(expectedFeatures))
+
+        let channelsGetArguments = channels.getArguments
+        let expectedFetchedChannelNames = [
+            "basketball::$chat::$chatMessages",
+            "basketball::$chat::$reactions",
+            "basketball::$chat::$typingIndicators",
+        ]
+        #expect(channelsGetArguments.count == expectedFetchedChannelNames.count)
+        #expect(Set(channelsGetArguments.map(\.name)) == Set(expectedFetchedChannelNames))
+    }
+
     // @specUntested CHA-RC2b - We chose to implement this failure with an idiomatic fatalError instead of throwing, but we can’t test this.
 
     // This is just a basic sense check to make sure the room getters are working as expected, since we don’t have unit tests for some of the features at the moment.

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -69,6 +69,49 @@ struct DefaultRoomTests {
 
     // @specUntested CHA-RC2b - We chose to implement this failure with an idiomatic fatalError instead of throwing, but we can’t test this.
 
+    // This is just a basic sense check to make sure the room getters are working as expected, since we don’t have unit tests for some of the features at the moment.
+    @Test(arguments: [.messages, .presence, .reactions, .occupancy, .typing] as[RoomFeature])
+    func whenFeatureEnabled_propertyGetterReturns(feature: RoomFeature) async throws {
+        // Given: A RoomOptions with the (test argument `feature`) feature enabled in the room options
+        let roomOptions: RoomOptions = switch feature {
+        case .messages:
+            // Messages should always be enabled without needing any special options
+            .init()
+        case .presence:
+            .init(presence: .init())
+        case .reactions:
+            .init(reactions: .init())
+        case .occupancy:
+            .init(occupancy: .init())
+        case .typing:
+            .init(typing: .init())
+        }
+
+        let channelsList = [
+            MockRealtimeChannel(name: "basketball::$chat::$chatMessages"),
+            MockRealtimeChannel(name: "basketball::$chat::$reactions"),
+            MockRealtimeChannel(name: "basketball::$chat::$typingIndicators"),
+        ]
+        let channels = MockChannels(channels: channelsList)
+        let realtime = MockRealtime.create(channels: channels)
+        let room = try await DefaultRoom(realtime: realtime, chatAPI: ChatAPI(realtime: realtime), roomID: "basketball", options: roomOptions, logger: TestLogger(), lifecycleManagerFactory: MockRoomLifecycleManagerFactory())
+
+        // When: We call the room’s getter for that feature
+        // Then: It returns an object (i.e. does not `fatalError()`)
+        switch feature {
+        case .messages:
+            #expect(room.messages is DefaultMessages)
+        case .presence:
+            #expect(room.presence is DefaultPresence)
+        case .reactions:
+            #expect(room.reactions is DefaultRoomReactions)
+        case .occupancy:
+            #expect(room.occupancy is DefaultOccupancy)
+        case .typing:
+            #expect(room.typing is DefaultTyping)
+        }
+    }
+
     // MARK: - Attach
 
     @Test(

--- a/Tests/AblyChatTests/DefaultRoomTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomTests.swift
@@ -67,6 +67,8 @@ struct DefaultRoomTests {
         #expect(room.messages.channel.name == "basketball::$chat::$chatMessages")
     }
 
+    // @specUntested CHA-RC2b - We chose to implement this failure with an idiomatic fatalError instead of throwing, but we can’t test this.
+
     // MARK: - Attach
 
     @Test(

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleManagerFactory.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleManagerFactory.swift
@@ -2,12 +2,14 @@
 
 actor MockRoomLifecycleManagerFactory: RoomLifecycleManagerFactory {
     private let manager: MockRoomLifecycleManager
+    private(set) var createManagerArguments: [(contributors: [DefaultRoomLifecycleContributor], logger: any InternalLogger)] = []
 
     init(manager: MockRoomLifecycleManager = .init()) {
         self.manager = manager
     }
 
-    func createManager(contributors _: [DefaultRoomLifecycleContributor], logger _: any InternalLogger) async -> MockRoomLifecycleManager {
-        manager
+    func createManager(contributors: [DefaultRoomLifecycleContributor], logger: any InternalLogger) async -> MockRoomLifecycleManager {
+        createManagerArguments.append((contributors: contributors, logger: logger))
+        return manager
     }
 }


### PR DESCRIPTION
Resolves #105. See commit messages for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new private enum to manage room features with options, enhancing feature initialization.
	- Updated room creation logic to utilize the new enum for better clarity and safety.

- **Bug Fixes**
	- Adjusted property access levels to allow concurrent access without actor isolation.

- **Tests**
	- Added new test methods to verify channel fetching and lifecycle contributor initialization based on enabled features.
	- Streamlined test setup by removing unnecessary parameters from channel mocks, improving test coverage for feature functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->