### PR TITLE
Split CI Xcode build and test into two steps

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -111,8 +111,13 @@ jobs:
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
-      - name: Build and run tests
-        run: swift run BuildTool build-and-test-library --platform ${{ matrix.platform }}
+      # We run these as two separate steps so that we can easily see the execution time of each step.
+
+      - name: Build for testing
+        run: swift run BuildTool build-library-for-testing --platform ${{ matrix.platform }}
+
+      - name: Run tests
+        run: swift run BuildTool test-library --platform ${{ matrix.platform }}
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})


### PR DESCRIPTION
I’m investigating a CI job that’s taking a long time to execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced separate commands for building and testing the library, enhancing clarity in the build process.
  
- **Bug Fixes**
	- Improved error handling and platform resolution in the build tool commands. 

- **Documentation**
	- Added descriptions and discussions for new commands to clarify their intended use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->