### PR TITLE
[ECO-5342] Renaming `Reaction` -> `RoomReaction`, `Messages.get` -> `Messages.history`

### DIFF
--- a/Example/AblyChatExample/Mocks/Misc.swift
+++ b/Example/AblyChatExample/Mocks/Misc.swift
@@ -89,7 +89,7 @@ enum ReactionType: String, CaseIterable {
     }
 }
 
-extension Reaction {
+extension RoomReaction {
     var displayedText: String {
         type
     }

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -151,7 +151,7 @@ class MockMessages: Messages {
         )
     }
 
-    func get(options _: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
+    func history(options _: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
         MockMessagesPaginatedResult(clientID: clientID, roomName: roomName)
     }
 
@@ -316,7 +316,7 @@ class MockRoomReactions: RoomReactions {
     }
 
     func send(params: SendReactionParams) async throws(ARTErrorInfo) {
-        let reaction = Reaction(
+        let reaction = RoomReaction(
             type: params.type,
             metadata: [:],
             headers: [:],
@@ -332,7 +332,7 @@ class MockRoomReactions: RoomReactions {
     func subscribe(_ callback: @escaping @MainActor (RoomReactionEvent) -> Void) -> SubscriptionProtocol {
         mockSubscriptions.create(
             randomElement: {
-                let reaction = Reaction(
+                let reaction = RoomReaction(
                     type: ReactionType.allCases.randomElement()!.emoji,
                     metadata: [:],
                     headers: [:],

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -22,8 +22,8 @@ internal final class DefaultMessages: Messages {
         try await implementation.subscribe(callback)
     }
 
-    internal func get(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
-        try await implementation.get(options: options)
+    internal func history(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
+        try await implementation.history(options: options)
     }
 
     internal func send(params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
@@ -161,7 +161,7 @@ internal final class DefaultMessages: Messages {
         }
 
         // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
-        internal func get(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
+        internal func history(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message> {
             do {
                 return try await chatAPI.getMessages(roomName: roomName, params: options)
             } catch {

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -81,7 +81,7 @@ internal final class DefaultRoomReactions: RoomReactions {
                     )
 
                     // (CHA-ER4d) Realtime events that are malformed (unknown fields should be ignored) shall not be emitted to listeners.
-                    let reaction = Reaction(
+                    let reaction = RoomReaction(
                         type: dto.type,
                         metadata: dto.metadata ?? [:],
                         headers: dto.headers ?? [:],

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -26,7 +26,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: A paginated result object that can be used to fetch more messages if available.
      */
-    func get(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>
+    func history(options: QueryOptions) async throws(ARTErrorInfo) -> any PaginatedResult<Message>
 
     /**
      * Send a message in the chat room.

--- a/Sources/AblyChat/RoomReaction.swift
+++ b/Sources/AblyChat/RoomReaction.swift
@@ -15,7 +15,7 @@ public typealias ReactionMetadata = Metadata
 /**
  * Represents a room-level reaction.
  */
-public struct Reaction: Sendable {
+public struct RoomReaction: Sendable {
     /**
      * The type of the reaction, for example "like" or "love".
      */

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -113,8 +113,8 @@ public enum RoomReactionEventType: String, Sendable {
 /// Event emitted by room reaction subscriptions, containing the type and the reaction.
 public struct RoomReactionEvent: Sendable {
     public let type: RoomReactionEventType
-    public let reaction: Reaction
-    public init(type: RoomReactionEventType = .reaction, reaction: Reaction) {
+    public let reaction: RoomReaction
+    public init(type: RoomReactionEventType = .reaction, reaction: RoomReaction) {
         self.type = type
         self.reaction = reaction
     }

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -277,7 +277,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let paginatedResult = try await defaultMessages.get(options: .init())
+        let paginatedResult = try await defaultMessages.history(options: .init())
 
         // Then
         // CHA-M6a: The method return a PaginatedResult containing messages
@@ -308,7 +308,7 @@ struct DefaultMessagesTests {
         // When
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await defaultMessages.get(options: .init())
+            _ = try await defaultMessages.history(options: .init())
         }
         // Then
         await #expect {


### PR DESCRIPTION
Renaming `Reaction` -> `RoomReaction`, `Messages.get` -> `Messages.history`

[ECO-5342]

[ECO-5342]: https://ably.atlassian.net/browse/ECO-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the `Reaction` struct to `RoomReaction` and updated all related references and property types.
  * Renamed the `get(options:)` method to `history(options:)` across relevant classes and protocols for message history retrieval.
  * Updated internal structures and event types to use the new `RoomReaction` type.
* **Tests**
  * Updated tests to use the renamed `history(options:)` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->