### PR TITLE
Unifies message reactions api across platforms

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -427,13 +427,13 @@ struct ContentView: View {
 
     func addMessageReaction(_ reaction: String, messageSerial: String) {
         Task {
-            try await room().messages.reactions.send(to: messageSerial, params: .init(reaction: reaction, type: .distinct))
+            try await room().messages.reactions.send(to: messageSerial, params: .init(name: reaction, type: .distinct))
         }
     }
 
     func deleteMessageReaction(_ reaction: String, messageSerial: String) {
         Task {
-            try await room().messages.reactions.delete(from: messageSerial, params: .init(reaction: reaction, type: .distinct))
+            try await room().messages.reactions.delete(from: messageSerial, params: .init(name: reaction, type: .distinct))
         }
     }
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -246,7 +246,7 @@ class MockMessageReactions: MessageReactions {
         reactions.append(
             MessageReaction(
                 type: .distinct,
-                name: params.reaction,
+                name: params.name,
                 messageSerial: messageSerial,
                 count: params.count,
                 clientID: clientID,
@@ -263,7 +263,7 @@ class MockMessageReactions: MessageReactions {
 
     func delete(from messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         reactions.removeAll { reaction in
-            reaction.messageSerial == messageSerial && reaction.name == params.reaction && reaction.clientID == clientID
+            reaction.messageSerial == messageSerial && reaction.name == params.name && reaction.clientID == clientID
         }
         mockSubscriptions.emit(
             MessageReactionSummaryEvent(

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -44,13 +44,13 @@ internal final class ChatAPI: Sendable {
 
     internal struct SendMessageReactionParams: Sendable {
         internal let type: MessageReactionType
-        internal let reaction: String
+        internal let name: String
         internal let count: Int?
     }
 
     internal struct DeleteMessageReactionParams: Sendable {
         internal let type: MessageReactionType
-        internal let reaction: String?
+        internal let name: String?
     }
 
     internal struct MessageReactionResponse: JSONObjectDecodable {
@@ -208,7 +208,7 @@ internal final class ChatAPI: Sendable {
 
         let ablyCocoaBody: [String: Any] = [
             "type": params.type.rawValue,
-            "name": params.reaction,
+            "name": params.name,
             "count": params.count ?? 1,
         ]
 
@@ -227,7 +227,7 @@ internal final class ChatAPI: Sendable {
         var httpParams: [String: String] = [
             "type": params.type.rawValue,
         ]
-        httpParams["name"] = params.reaction
+        httpParams["name"] = params.name
 
         return try await makeRequest(endpoint, method: "DELETE", params: httpParams)
     }

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -29,7 +29,7 @@ internal final class DefaultMessageReactions: MessageReactions {
 
             let apiParams: ChatAPI.SendMessageReactionParams = .init(
                 type: params.type ?? defaultReaction,
-                reaction: params.reaction,
+                name: params.name,
                 count: count
             )
             let response = try await chatAPI.sendReactionToMessage(messageSerial, roomName: roomName, params: apiParams)
@@ -43,13 +43,13 @@ internal final class DefaultMessageReactions: MessageReactions {
     // (CHA-MR11) Users should be able to delete a reaction from a message via the `delete` method of the `MessagesReactions` object
     internal func delete(from messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         let reactionType = params.type ?? defaultReaction
-        if reactionType != .unique, params.reaction == nil {
+        if reactionType != .unique, params.name == nil {
             throw ARTErrorInfo(chatError: .unableDeleteReactionWithoutName(reactionType: reactionType.rawValue))
         }
         do {
             let apiParams: ChatAPI.DeleteMessageReactionParams = .init(
                 type: reactionType,
-                reaction: reactionType != .unique ? params.reaction : nil
+                name: reactionType != .unique ? params.name : nil
             )
             let response = try await chatAPI.deleteReactionFromMessage(messageSerial, roomName: roomName, params: apiParams)
 

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -126,7 +126,7 @@ public struct SendMessageReactionParams: Sendable {
     /**
      * The reaction to add; ie. the emoji.
      */
-    public var reaction: String
+    public var name: String
 
     /**
      * The count of the reaction for type ``MessageReactionType/multiple``.
@@ -134,8 +134,8 @@ public struct SendMessageReactionParams: Sendable {
      */
     public var count: Int?
 
-    public init(reaction: String, type: MessageReactionType? = nil, count: Int? = nil) {
-        self.reaction = reaction
+    public init(name: String, type: MessageReactionType? = nil, count: Int? = nil) {
+        self.name = name
         self.type = type
         self.count = count
     }
@@ -151,13 +151,13 @@ public struct DeleteMessageReactionParams: Sendable {
     public var type: MessageReactionType?
 
     /**
-     * The reaction to remove, ie. the emoji. Required for all reaction types
+     * The reaction to remove, ie. the emoji name. Required for all reaction types
      * except ``MessageReactionType/unique``.
      */
-    public var reaction: String?
+    public var name: String?
 
-    public init(reaction: String? = nil, type: MessageReactionType? = nil) {
-        self.reaction = reaction
+    public init(name: String? = nil, type: MessageReactionType? = nil) {
+        self.name = name
         self.type = type
     }
 }

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -140,10 +140,10 @@ struct IntegrationTests {
 
         let rxMessageReactionsSubscription = rxRoom.messages.reactions.subscribe()
 
-        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "👍"))
-        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "🎉"))
-        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "👍"))
-        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "🎉"))
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(name: "👍"))
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(name: "🎉"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(name: "👍"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(name: "🎉"))
 
         var reactionSummaryEvents = [MessageReactionSummaryEvent]()
 
@@ -188,9 +188,9 @@ struct IntegrationTests {
 
         let rxMessageRawReactionsSubscription = rxRoom.messages.reactions.subscribeRaw()
 
-        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "🔥"))
-        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(reaction: "😆"))
-        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(reaction: "😆")) // not deleting 🔥 to check it later in history request
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(name: "🔥"))
+        try await txRoom.messages.reactions.send(to: messageToReact.serial, params: .init(name: "😆"))
+        try await txRoom.messages.reactions.delete(from: messageToReact.serial, params: .init(name: "😆")) // not deleting 🔥 to check it later in history request
 
         var reactionRawEvents = [MessageReactionRawEvent]()
 


### PR DESCRIPTION
https://github.com/ably/docs/pull/2699#discussion_r2185221572

Makes API consistent between different SDKs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the parameter name for message reactions from "reaction" to "name" throughout the app for consistency and clarity.
  * Adjusted related documentation to reflect the new naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->