### PR TITLE
[ECO-5423] The rest of errors via chat error

### DIFF
--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -201,22 +201,13 @@ internal final class DefaultMessages: Messages {
                             continuation.resume(returning: .success(subscriptionPoint))
                         } else {
                             logger.log(message: "Channel is attached, but attachSerial is not defined", level: .error)
-                            continuation.resume(returning: .failure(ARTErrorInfo.create(withCode: 40000, status: 400, message: "Channel is attached, but attachSerial is not defined").toInternalError()))
+                            continuation.resume(returning: .failure(ARTErrorInfo(chatError: .attachSerialIsNotDefined).toInternalError()))
                         }
                     case .failed, .suspended:
                         // TODO: Revisit as part of https://github.com/ably-labs/ably-chat-swift/issues/32
-                        logger.log(message: "Channel failed to attach", level: .error)
-                        let errorCodeCase = ErrorCode.CaseThatImpliesFixedStatusCode.badRequest
-                        continuation.resume(
-                            returning: .failure(
-                                ARTErrorInfo.create(
-                                    withCode: errorCodeCase.toNumericErrorCode.rawValue,
-                                    status: errorCodeCase.statusCode,
-                                    message: "Channel failed to attach"
-                                )
-                                .toInternalError()
-                            )
-                        )
+                        let error = ARTErrorInfo(chatError: .channelFailedToAttach(cause: stateChange.reason)).toInternalError()
+                        logger.log(message: "\(error)", level: .error)
+                        continuation.resume(returning: .failure(error))
                     default:
                         break
                     }

--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -175,6 +175,8 @@ internal enum ChatError {
     case messageRejectedByBeforePublishRule
     case messageRejectedByModeration
     case clientIdRequired
+    case attachSerialIsNotDefined
+    case channelFailedToAttach(cause: ARTErrorInfo?)
 
     internal var codeAndStatusCode: ErrorCodeAndStatusCode {
         switch self {
@@ -209,6 +211,10 @@ internal enum ChatError {
             .fixedStatusCode(.messageRejectedByModeration)
         case .clientIdRequired:
             .fixedStatusCode(.clientIdRequired)
+        case .attachSerialIsNotDefined:
+            .fixedStatusCode(.badRequest)
+        case .channelFailedToAttach:
+            .fixedStatusCode(.badRequest)
         }
     }
 
@@ -265,6 +271,10 @@ internal enum ChatError {
             "The message was rejected before publishing by a moderation rule on the chat room."
         case .clientIdRequired:
             "Ensure your Realtime instance is initialized with a clientId."
+        case .attachSerialIsNotDefined:
+            "Channel is attached, but attachSerial is not defined."
+        case let .channelFailedToAttach(cause):
+            "Channel failed to attach: \(String(describing: cause))"
         }
     }
 
@@ -274,6 +284,8 @@ internal enum ChatError {
         case let .roomTransitionedToInvalidStateForPresenceOperation(cause):
             cause
         case let .roomDiscontinuity(cause):
+            cause
+        case let .channelFailedToAttach(cause):
             cause
         case .nonErrorInfoInternalError,
              .inconsistentRoomOptions,
@@ -286,7 +298,8 @@ internal enum ChatError {
              .unableDeleteReactionWithoutName,
              .messageRejectedByBeforePublishRule,
              .messageRejectedByModeration,
-             .clientIdRequired:
+             .clientIdRequired,
+             .attachSerialIsNotDefined:
             nil
         }
     }


### PR DESCRIPTION
Closes #301 

Related PR - https://github.com/ably/ably-chat-swift/pull/331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and memory management for chat message, reaction, occupancy, and presence event handling, reducing the risk of crashes and retain cycles.
  * Presence events now gracefully handle missing fields by using sensible defaults instead of throwing errors.

* **Improvements**
  * Enhanced error reporting for channel attachment issues, providing clearer and more specific error messages.

* **Tests**
  * Added a new test to ensure invalid occupancy events emit zero values for connections and presence members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->