### PR TITLE
Adds new getting started link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Ably Chat is a set of purpose-built APIs for a host of chat features enabling yo
 
 Everything you need to get started with Ably:
 
-* [Getting started with Ably Chat using Swift.](https://ably.com/docs/chat/getting-started/swift)
-* [Ably Chat SDK and usage docs in Swift.](https://ably.com/docs/chat/setup?lang=swift)
-* Learn [about Ably Chat.](https://ably.com/docs/chat)
-* Play with the [livestream chat demo.](https://ably-livestream-chat-demo.vercel.app/)
+- [Getting started with Ably Chat using Swift.](https://ably.com/docs/chat/getting-started/swift)
+- [Ably Chat SDK and usage docs in Swift.](https://ably.com/docs/chat/setup?lang=swift)
+- Learn [about Ably Chat.](https://ably.com/docs/chat)
+- Play with the [livestream chat demo.](https://ably-livestream-chat-demo.vercel.app/)
 
 ---
 
@@ -28,7 +28,7 @@ Ably aims to support a wide range of platforms. If you experience any compatibil
 This SDK supports the following platforms:
 
 | Platform | Support |
-|----------|---------|
+| -------- | ------- |
 | iOS      | >= 14.0 |
 | macOS    | >= 11.0 |
 | tvOS     | >= 14.0 |


### PR DESCRIPTION
This PR:

- Add new "Getting started with Pub/Sub using Swift" documentation link
- Fix Swift compatibility badge to reference correct repository (ably-chat-swift vs ably-cocoa)
- Update license badge to point to ably-chat-swift instead of ably-chat-kotlin
- Fix CHANGELOG.md link to use relative path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Swift compatibility badge source to Swift Package Index and revised license badge to reference the repo license.
  * Reworked "Getting Started" list (bullet style changed, items reordered, two new top bullets added, two removed) and clarified the livestream demo link.
  * Updated Releases/CHANGELOG link to point to the repository root CHANGELOG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->