### PR TITLE
presence: make data a json object

### DIFF
--- a/Example/AblyChatExample/MessageViews/PresenceMessageView.swift
+++ b/Example/AblyChatExample/MessageViews/PresenceMessageView.swift
@@ -22,7 +22,7 @@ struct PresenceMessageView: View {
     }
 
     func generatePresenceMessage() -> String {
-        let status = item.presence.member.data?.objectValue?["status"]?.stringValue
+        let status = item.presence.member.data?["status"]?.stringValue
         let clientPresenceChangeMessage = "\(item.presence.member.clientID) \(item.presence.type)"
         let presenceMessage = status != nil ? "\(clientPresenceChangeMessage) with status: \(status!)" : clientPresenceChangeMessage
         return presenceMessage

--- a/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
@@ -76,13 +76,13 @@ internal protocol InternalRealtimeChannelProtocol: AnyObject, Sendable {
 internal protocol InternalRealtimePresenceProtocol: AnyObject, Sendable {
     func get() async throws(InternalError) -> [PresenceMessage]
     func get(_ query: ARTRealtimePresenceQuery) async throws(InternalError) -> [PresenceMessage]
-    func leave(_ data: JSONValue?) async throws(InternalError)
-    func enterClient(_ clientID: String, data: JSONValue?) async throws(InternalError)
-    func update(_ data: JSONValue?) async throws(InternalError)
+    func leave(_ data: JSONObject?) async throws(InternalError)
+    func enterClient(_ clientID: String, data: JSONObject?) async throws(InternalError)
+    func update(_ data: JSONObject?) async throws(InternalError)
     func subscribe(_ callback: @escaping @MainActor (ARTPresenceMessage) -> Void) -> ARTEventListener?
     func subscribe(_ action: ARTPresenceAction, callback: @escaping @MainActor (ARTPresenceMessage) -> Void) -> ARTEventListener?
     func unsubscribe(_ listener: ARTEventListener)
-    func leaveClient(_ clientId: String, data: JSONValue?) async throws(InternalError)
+    func leaveClient(_ clientId: String, data: JSONObject?) async throws(InternalError)
 }
 
 /// Expresses the requirements of the object returned by ``InternalRealtimeChannelProtocol/annotations``.
@@ -336,7 +336,7 @@ internal final class InternalRealtimeClientAdapter: InternalRealtimeClientProtoc
             }
         }
 
-        internal func leave(_ data: JSONValue?) async throws(InternalError) {
+        internal func leave(_ data: JSONObject?) async throws(InternalError) {
             do {
                 try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
                     underlying.leave(data?.toAblyCocoaData) { error in
@@ -352,7 +352,7 @@ internal final class InternalRealtimeClientAdapter: InternalRealtimeClientProtoc
             }
         }
 
-        internal func enterClient(_ clientID: String, data: JSONValue?) async throws(InternalError) {
+        internal func enterClient(_ clientID: String, data: JSONObject?) async throws(InternalError) {
             do {
                 try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
                     underlying.enterClient(clientID, data: data?.toAblyCocoaData) { error in
@@ -368,7 +368,7 @@ internal final class InternalRealtimeClientAdapter: InternalRealtimeClientProtoc
             }
         }
 
-        internal func update(_ data: JSONValue?) async throws(InternalError) {
+        internal func update(_ data: JSONObject?) async throws(InternalError) {
             do {
                 try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
                     underlying.update(data?.toAblyCocoaData) { error in
@@ -396,7 +396,7 @@ internal final class InternalRealtimeClientAdapter: InternalRealtimeClientProtoc
             underlying.unsubscribe(listener)
         }
 
-        internal func leaveClient(_ clientID: String, data: JSONValue?) async throws(InternalError) {
+        internal func leaveClient(_ clientID: String, data: JSONObject?) async throws(InternalError) {
             do {
                 try await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, ARTErrorInfo>, _>) in
                     underlying.leaveClient(clientID, data: data?.toAblyCocoaData) { error in
@@ -463,7 +463,7 @@ internal struct PresenceMessage {
     internal var clientId: String?
     internal var timestamp: Date?
     internal var action: ARTPresenceAction
-    internal var data: JSONValue?
+    internal var data: JSONObject?
     internal var extras: [String: JSONValue]?
 }
 
@@ -473,7 +473,7 @@ internal extension PresenceMessage {
         timestamp = ablyCocoaPresenceMessage.timestamp
         action = ablyCocoaPresenceMessage.action
         if let ablyCocoaData = ablyCocoaPresenceMessage.data {
-            data = .init(ablyCocoaData: ablyCocoaData)
+            data = JSONValue(ablyCocoaData: ablyCocoaData).objectValue
         }
         if let ablyCocoaExtras = ablyCocoaPresenceMessage.extras {
             extras = JSONValue.objectFromAblyCocoaExtras(ablyCocoaExtras)

--- a/Sources/AblyChat/JSONValue.swift
+++ b/Sources/AblyChat/JSONValue.swift
@@ -1,6 +1,9 @@
 import Ably
 import Foundation
 
+/// A JSON object (where "object" has the meaning defined by the [JSON specification](https://www.json.org)).
+public typealias JSONObject = [String: JSONValue]
+
 /// A JSON value (where "value" has the meaning defined by the [JSON specification](https://www.json.org)).
 ///
 /// `JSONValue` provides a type-safe API for working with JSON values. It implements Swift’s `ExpressibleBy*Literal` protocols. This allows you to write type-safe JSON values using familiar syntax. For example:
@@ -26,7 +29,7 @@ import Foundation
 ///
 /// > Note: To write a `JSONValue` that corresponds to the `null` JSON value, you must explicitly write `.null`. `JSONValue` deliberately does not implement the `ExpressibleByNilLiteral` protocol in order to avoid confusion between a value of type `JSONValue?` and a `JSONValue` with case `.null`.
 public indirect enum JSONValue: Sendable, Equatable {
-    case object([String: JSONValue])
+    case object(JSONObject)
     case array([JSONValue])
     case string(String)
     case number(Double)
@@ -36,7 +39,7 @@ public indirect enum JSONValue: Sendable, Equatable {
     // MARK: - Convenience getters for associated values
 
     /// If this `JSONValue` has case `object`, this returns the associated value. Else, it returns `nil`.
-    public var objectValue: [String: JSONValue]? {
+    public var objectValue: JSONObject? {
         if case let .object(objectValue) = self {
             objectValue
         } else {
@@ -198,7 +201,7 @@ internal extension JSONValue {
     }
 }
 
-internal extension [String: JSONValue] {
+internal extension JSONObject {
     /// Creates an ably-cocoa deserialized JSON object from a dictionary that has string keys and `JSONValue` values.
     ///
     /// Specifically, the value of this property can be used as:
@@ -208,6 +211,11 @@ internal extension [String: JSONValue] {
     /// - the `data` argument that’s passed to `ARTRealtime`’s `publish(…)` method
     var toAblyCocoaDataDictionary: [String: Any] {
         mapValues(\.toAblyCocoaData)
+    }
+
+    /// Creates an ably-cocoa data object from a dictionary that has string keys and `JSONValue` values.
+    var toAblyCocoaData: Any {
+        toAblyCocoaDataDictionary
     }
 
     /// Creates an ably-cocoa `ARTJsonCompatible` object from a dictionary that has string keys and `JSONValue` values.

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -1,6 +1,6 @@
 import Ably
 
-public typealias PresenceData = JSONValue
+public typealias PresenceData = JSONObject
 
 /**
  * This interface is used to interact with presence in a chat room: subscribing to presence events,

--- a/Tests/AblyChatTests/DefaultPresenceTests.swift
+++ b/Tests/AblyChatTests/DefaultPresenceTests.swift
@@ -27,7 +27,33 @@ struct DefaultPresenceTests {
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
             matching: "enterClient(_:data:)",
-            arguments: ["name": "client1", "data": JSONValue.object(["status": "Online"])]
+            arguments: ["name": "client1", "data": ["status": JSONValue.string("Online")]]
+        )
+        )
+    }
+
+    // @spec CHA-PR3a
+    @Test
+    func usersMayEnterPresenceWithoutData() async throws {
+        // Given
+        let channel = await MockRealtimeChannel(name: "basketball::$chat::$chatMessages")
+        let logger = TestLogger()
+        let defaultPresence = await DefaultPresence(
+            channel: channel,
+            roomLifecycleManager: MockRoomLifecycleManager(),
+            roomName: "basketball",
+            clientID: "client1",
+            logger: logger,
+            options: .init()
+        )
+
+        // When
+        try await defaultPresence.enter()
+
+        // Then
+        #expect(channel.presence.callRecorder.hasRecord(
+            matching: "enterClient(_:data:)",
+            arguments: ["data": nil, "name": "client1"]
         )
         )
     }
@@ -150,7 +176,7 @@ struct DefaultPresenceTests {
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
             matching: "update(_:)",
-            arguments: ["data": JSONValue.object(["status": "Online"])]
+            arguments: ["data": ["status": JSONValue.string("Online")]]
         )
         )
     }
@@ -273,7 +299,7 @@ struct DefaultPresenceTests {
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
             matching: "leave(_:)",
-            arguments: ["data": JSONValue.object(["status": "Online"])]
+            arguments: ["data": ["status": JSONValue.string("Online")]]
         )
         )
     }

--- a/Tests/AblyChatTests/Helpers/Helpers.swift
+++ b/Tests/AblyChatTests/Helpers/Helpers.swift
@@ -149,7 +149,7 @@ class MockMethodCallRecorder: @unchecked Sendable {
         }
     }
 
-    func hasRecord(matching signature: String, arguments: [String: Any]) -> Bool {
+    func hasRecord(matching signature: String, arguments: [String: Any?]) -> Bool {
         mutex.withLock {
             records.contains { record in
                 guard record.signature == signature else {

--- a/Tests/AblyChatTests/Mocks/MockRealtimePresence.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimePresence.swift
@@ -16,7 +16,7 @@ final class MockRealtimePresence: InternalRealtimePresenceProtocol {
         // no-op since it's called automatically
     }
 
-    func leaveClient(_: String, data _: JSONValue?) {
+    func leaveClient(_: String, data _: JSONObject?) {
         fatalError("Not implemented")
     }
 
@@ -36,21 +36,21 @@ final class MockRealtimePresence: InternalRealtimePresenceProtocol {
         return []
     }
 
-    func leave(_ data: JSONValue?) async throws(InternalError) {
+    func leave(_ data: JSONObject?) async throws(InternalError) {
         callRecorder.addRecord(
             signature: "leave(_:)",
             arguments: ["data": data]
         )
     }
 
-    func enterClient(_ name: String, data: JSONValue?) async throws(InternalError) {
+    func enterClient(_ name: String, data: JSONObject?) async throws(InternalError) {
         callRecorder.addRecord(
             signature: "enterClient(_:data:)",
             arguments: ["name": name, "data": data]
         )
     }
 
-    func update(_ data: JSONValue?) async throws(InternalError) {
+    func update(_ data: JSONObject?) async throws(InternalError) {
         callRecorder.addRecord(
             signature: "update(_:)",
             arguments: ["data": data]


### PR DESCRIPTION
This change makes `PresenceData` a JSON object rather than any JSON value.

[CHA-1166]

[CHA-1166]: https://ably.atlassian.net/browse/CHA-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now join presence without providing status data.
- Bug Fixes
  - Presence messages handle missing or null status more gracefully, improving reliability of status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->