### PR TITLE
Enable a couple of upcoming language features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let commonSwiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("ExistentialAny"),
 ]
 
 let package = Package(

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -66,7 +66,7 @@ public class DefaultChatClient: ChatClient {
         _rooms
     }
 
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
 
     // (CHA-CS1) Every chat client has a status, which describes the current status of the connection.
     // (CHA-CS4) The chat client must allow its connection status to be observed by clients.
@@ -121,7 +121,7 @@ public struct ChatClientOptions: Sendable {
      *
      * By default, the client will log messages to the console.
      */
-    public var logHandler: LogHandler?
+    public var logHandler: (any LogHandler)?
 
     /**
      * The minimum log level at which messages will be logged.

--- a/Sources/AblyChat/Connection.swift
+++ b/Sources/AblyChat/Connection.swift
@@ -25,7 +25,7 @@ public protocol Connection: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``ConnectionStatusChange`` events.
      */
     @discardableResult
-    func onStatusChange(_ callback: @escaping @MainActor (ConnectionStatusChange) -> Void) -> StatusSubscriptionProtocol
+    func onStatusChange(_ callback: @escaping @MainActor (ConnectionStatusChange) -> Void) -> any StatusSubscriptionProtocol
 }
 
 /// `AsyncSequence` variant of `Connection` status changes.

--- a/Sources/AblyChat/DefaultConnection.swift
+++ b/Sources/AblyChat/DefaultConnection.swift
@@ -21,7 +21,7 @@ internal final class DefaultConnection: Connection {
 
     // (CHA-CS4d) Clients must be able to register a listener for connection status events and receive such events.
     @discardableResult
-    internal func onStatusChange(_ callback: @escaping @MainActor (ConnectionStatusChange) -> Void) -> StatusSubscriptionProtocol {
+    internal func onStatusChange(_ callback: @escaping @MainActor (ConnectionStatusChange) -> Void) -> any StatusSubscriptionProtocol {
         // (CHA-CS5) The chat client must monitor the underlying realtime connection for connection status changes.
         let eventListener = realtime.connection.on { [weak self] stateChange in
             guard let self else {

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -4,12 +4,12 @@ import Ably
 internal final class DefaultMessageReactions: MessageReactions {
     private let channel: any InternalRealtimeChannelProtocol
     private let roomName: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let clientID: String
     private let chatAPI: ChatAPI
     private let options: MessagesOptions
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions, clientID: String, logger: InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions, clientID: String, logger: any InternalLogger) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName
@@ -60,7 +60,7 @@ internal final class DefaultMessageReactions: MessageReactions {
 
     // (CHA-MR6) Users must be able to subscribe to message reaction summaries via the subscribe method of the MessagesReactions object. The events emitted will be of type MessageReactionSummaryEvent.
     @discardableResult
-    internal func subscribe(_ callback: @escaping @MainActor @Sendable (MessageReactionSummaryEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor @Sendable (MessageReactionSummaryEvent) -> Void) -> any SubscriptionProtocol {
         logger.log(message: "Subscribing to message reaction summary events", level: .debug)
 
         let eventListener = channel.subscribe { [weak self] message in
@@ -101,7 +101,7 @@ internal final class DefaultMessageReactions: MessageReactions {
 
     // (CHA-MR7) Users must be able to subscribe to raw message reactions (as individual annotations) via the subscribeRaw method of the MessagesReactions object. The events emitted are of type MessageReactionRawEvent.
     @discardableResult
-    internal func subscribeRaw(_ callback: @escaping @MainActor @Sendable (MessageReactionRawEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribeRaw(_ callback: @escaping @MainActor @Sendable (MessageReactionRawEvent) -> Void) -> any SubscriptionProtocol {
         logger.log(message: "Subscribing to reaction events", level: .debug)
         guard options.rawMessageReactions else {
             // (CHA-MR7a) The attempt to subscribe to raw message reactions must throw an ErrorInfo with code 40000 and status code 400 if the room is not configured to support raw message reactions

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -8,7 +8,7 @@ internal final class DefaultMessages: Messages {
     private let roomName: String
     private let chatAPI: ChatAPI
     private let clientID: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
 
     private var currentSubscriptionPoint: String?
     private var subscriptionPoints: [UUID: String] = [:]
@@ -26,7 +26,7 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions = .init(), clientID: String, logger: InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions = .init(), clientID: String, logger: any InternalLogger) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName
@@ -36,7 +36,7 @@ internal final class DefaultMessages: Messages {
         updateCurrentSubscriptionPoint()
     }
 
-    internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> any MessageSubscriptionResponseProtocol {
         logger.log(message: "Subscribing to messages", level: .debug)
         // (CHA-M4c) When a realtime message with name set to message.created is received, it is translated into a message event, which contains a type field with the event type as well as a message field containing the Message Struct. This event is then broadcast to all subscribers.
         // (CHA-M4d) If a realtime message with an unknown name is received, the SDK shall silently discard the message, though it may log at DEBUG or TRACE level.

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -4,12 +4,12 @@ internal final class DefaultOccupancy: Occupancy {
     private let channel: any InternalRealtimeChannelProtocol
     private let chatAPI: ChatAPI
     private let roomName: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let options: OccupancyOptions
 
     private var lastOccupancyData: OccupancyData?
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, logger: InternalLogger, options: OccupancyOptions) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, logger: any InternalLogger, options: OccupancyOptions) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName
@@ -18,7 +18,7 @@ internal final class DefaultOccupancy: Occupancy {
     }
 
     @discardableResult
-    internal func subscribe(_ callback: @escaping @MainActor (OccupancyEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor (OccupancyEvent) -> Void) -> any SubscriptionProtocol {
         // CHA-O4e (we use a fatalError for this programmer error, which is the idiomatic thing to do for Swift)
         guard options.enableEvents else {
             fatalError("In order to be able to subscribe to presence events, please set enableEvents to true in the room's occupancy options.")

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -5,10 +5,10 @@ internal final class DefaultPresence: Presence {
     private let roomLifecycleManager: any RoomLifecycleManager
     private let roomName: String
     private let clientID: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let options: PresenceOptions
 
-    internal init(channel: any InternalRealtimeChannelProtocol, roomLifecycleManager: any RoomLifecycleManager, roomName: String, clientID: String, logger: InternalLogger, options: PresenceOptions) {
+    internal init(channel: any InternalRealtimeChannelProtocol, roomLifecycleManager: any RoomLifecycleManager, roomName: String, clientID: String, logger: any InternalLogger, options: PresenceOptions) {
         self.channel = channel
         self.roomLifecycleManager = roomLifecycleManager
         self.roomName = roomName
@@ -199,7 +199,7 @@ internal final class DefaultPresence: Presence {
 
     // (CHA-PR7a) Users may provide a listener to subscribe to all presence events in a room.
     // (CHA-PR7b) Users may provide a listener and a list of selected presence events, to subscribe to just those events in a room.
-    internal func subscribe(event: PresenceEventType, _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(event: PresenceEventType, _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> any SubscriptionProtocol {
         fatalErrorIfEnableEventsDisabled()
 
         logger.log(message: "Subscribing to presence events", level: .debug)
@@ -221,7 +221,7 @@ internal final class DefaultPresence: Presence {
         }
     }
 
-    internal func subscribe(events: [PresenceEventType], _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(events: [PresenceEventType], _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> any SubscriptionProtocol {
         fatalErrorIfEnableEventsDisabled()
 
         logger.log(message: "Subscribing to presence events", level: .debug)

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -3,10 +3,10 @@ import Ably
 internal final class DefaultRoomReactions: RoomReactions {
     private let channel: any InternalRealtimeChannelProtocol
     private let roomName: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let clientID: String
 
-    internal init(channel: any InternalRealtimeChannelProtocol, clientID: String, roomName: String, logger: InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, clientID: String, roomName: String, logger: any InternalLogger) {
         self.roomName = roomName
         self.channel = channel
         self.logger = logger
@@ -34,7 +34,7 @@ internal final class DefaultRoomReactions: RoomReactions {
     // (CHA-ER4) A user may subscribe to reaction events in Realtime.
     // (CHA-ER4a) A user may provide a listener to subscribe to reaction events. This operation must have no side-effects in relation to room or underlying status. When a realtime message with name roomReaction is received, this message is converted into a reaction object and emitted to subscribers.
     @discardableResult
-    internal func subscribe(_ callback: @escaping @MainActor (RoomReactionEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor (RoomReactionEvent) -> Void) -> any SubscriptionProtocol {
         logger.log(message: "Subscribing to reaction events", level: .debug)
 
         // (CHA-ER4c) Realtime events with an unknown name shall be silently discarded.

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -4,13 +4,13 @@ internal final class DefaultTyping: Typing {
     private let channel: any InternalRealtimeChannelProtocol
     private let roomName: String
     private let clientID: String
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let heartbeatThrottle: TimeInterval
 
     // (CHA-T10a) A grace period shall be set by the client (the grace period on the CHA-T10 heartbeat interval when receiving events). The default value shall be set to 2000ms.
     private let gracePeriod: TimeInterval = 2
 
-    private let typingTimerManager: TypingTimerManagerProtocol
+    private let typingTimerManager: any TypingTimerManagerProtocol
 
     // (CHA-T14) Multiple asynchronous calls to keystroke/stop typing must eventually converge to a consistent state.
     // (CHA-TM14a) When a call to keystroke or stop is made, it should attempt to acquire a mutex lock.
@@ -18,7 +18,7 @@ internal final class DefaultTyping: Typing {
     // (CHA-TM14b1) During this time, each new subsequent call to either function shall abort the previously queued call. In doing so, there shall only ever be one pending call and while the mutex is held, thus the most recent call shall "win" and execute once the mutex is released.
     private let keyboardOperationQueue = TypingOperationQueue<InternalError>()
 
-    internal init(channel: any InternalRealtimeChannelProtocol, roomName: String, clientID: String, logger: InternalLogger, heartbeatThrottle: TimeInterval, clock: some ClockProtocol) {
+    internal init(channel: any InternalRealtimeChannelProtocol, roomName: String, clientID: String, logger: any InternalLogger, heartbeatThrottle: TimeInterval, clock: some ClockProtocol) {
         self.roomName = roomName
         self.channel = channel
         self.clientID = clientID
@@ -35,7 +35,7 @@ internal final class DefaultTyping: Typing {
 
     // (CHA-T6) Users may subscribe to typing events – updates to a set of clientIDs that are typing. This operation, like all subscription operations, has no side-effects in relation to room lifecycle.
     @discardableResult
-    internal func subscribe(_ callback: @escaping @MainActor (TypingSetEvent) -> Void) -> SubscriptionProtocol {
+    internal func subscribe(_ callback: @escaping @MainActor (TypingSetEvent) -> Void) -> any SubscriptionProtocol {
         // (CHA-T6a) Users may provide a listener to subscribe to typing event V2 in a chat room.
         let startedEventListener = channel.subscribe(TypingEventType.started.rawValue) { [weak self] message in
             guard let self, let messageClientID = message.clientId else {

--- a/Sources/AblyChat/JSONValue.swift
+++ b/Sources/AblyChat/JSONValue.swift
@@ -219,7 +219,7 @@ internal extension JSONObject {
     }
 
     /// Creates an ably-cocoa `ARTJsonCompatible` object from a dictionary that has string keys and `JSONValue` values.
-    var toARTJsonCompatible: ARTJsonCompatible {
-        toAblyCocoaDataDictionary as ARTJsonCompatible
+    var toARTJsonCompatible: any ARTJsonCompatible {
+        toAblyCocoaDataDictionary as (any ARTJsonCompatible)
     }
 }

--- a/Sources/AblyChat/Logging.swift
+++ b/Sources/AblyChat/Logging.swift
@@ -55,10 +55,10 @@ extension InternalLogger {
 }
 
 internal final class DefaultInternalLogger: InternalLogger {
-    private let logHandler: LogHandler
+    private let logHandler: any LogHandler
 
     #if DEBUG
-        internal var testsOnly_logHandler: LogHandler {
+        internal var testsOnly_logHandler: any LogHandler {
             logHandler
         }
     #endif
@@ -71,7 +71,7 @@ internal final class DefaultInternalLogger: InternalLogger {
         }
     #endif
 
-    internal init(logHandler: LogHandler?, logLevel: LogLevel?) {
+    internal init(logHandler: (any LogHandler)?, logLevel: LogLevel?) {
         self.logHandler = logHandler ?? DefaultLogHandler()
         self.logLevel = logLevel ?? .error
     }

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -36,7 +36,7 @@ public protocol MessageReactions: AnyObject, Sendable {
      * - Returns: A subscription handle object that should be used to unsubscribe.
      */
     @discardableResult
-    func subscribe(_ callback: @escaping @MainActor (MessageReactionSummaryEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(_ callback: @escaping @MainActor (MessageReactionSummaryEvent) -> Void) -> any SubscriptionProtocol
 
     /**
      * Subscribe to individual reaction events.
@@ -49,7 +49,7 @@ public protocol MessageReactions: AnyObject, Sendable {
      * - Note: If you only need to keep track of reaction counts and clients, use ``subscribe(_:)`` instead.
      */
     @discardableResult
-    func subscribeRaw(_ callback: @escaping @MainActor (MessageReactionRawEvent) -> Void) -> SubscriptionProtocol
+    func subscribeRaw(_ callback: @escaping @MainActor (MessageReactionRawEvent) -> Void) -> any SubscriptionProtocol
 }
 
 /// `AsyncSequence` variant of receiving message reactions events.

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -16,7 +16,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: A subscription that can be used to unsubscribe from `ChatMessageEvent` events.
      */
-    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> MessageSubscriptionResponseProtocol
+    func subscribe(_ callback: @escaping @MainActor (ChatMessageEvent) -> Void) -> any MessageSubscriptionResponseProtocol
 
     /**
      * Get messages that have been previously sent to the chat room, based on the provided options.
@@ -76,7 +76,7 @@ public protocol Messages: AnyObject, Sendable {
     /**
      * Add, delete, and subscribe to message reactions.
      */
-    var reactions: MessageReactions { get }
+    var reactions: any MessageReactions { get }
 }
 
 public extension Messages {

--- a/Sources/AblyChat/Occupancy.swift
+++ b/Sources/AblyChat/Occupancy.swift
@@ -19,7 +19,7 @@ public protocol Occupancy: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``OccupancyEvent`` events.
      */
     @discardableResult
-    func subscribe(_ callback: @escaping @MainActor (OccupancyEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(_ callback: @escaping @MainActor (OccupancyEvent) -> Void) -> any SubscriptionProtocol
 
     /**
      * Get the current occupancy of the chat room.

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -81,7 +81,7 @@ public protocol Presence: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``PresenceEvent`` events.
      */
     @discardableResult
-    func subscribe(event: PresenceEventType, _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(event: PresenceEventType, _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> any SubscriptionProtocol
 
     /**
      * Subscribes a given listener to different presence events in the chat room.
@@ -95,7 +95,7 @@ public protocol Presence: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``PresenceEvent`` events.
      */
     @discardableResult
-    func subscribe(events: [PresenceEventType], _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(events: [PresenceEventType], _ callback: @escaping @MainActor (PresenceEvent) -> Void) -> any SubscriptionProtocol
 
     /**
      * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -73,7 +73,7 @@ public protocol Room: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``RoomStatusChange`` events.
      */
     @discardableResult
-    func onStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> StatusSubscriptionProtocol
+    func onStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> any StatusSubscriptionProtocol
 
     /**
      * Subscribes a given listener to a detected discontinuity.
@@ -84,7 +84,7 @@ public protocol Room: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``DiscontinuityEvent``.
      */
     @discardableResult
-    func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> StatusSubscriptionProtocol
+    func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> any StatusSubscriptionProtocol
 
     /**
      * Attaches to the room to receive events in realtime.
@@ -212,13 +212,13 @@ internal protocol RoomFactory: Sendable {
     associatedtype Realtime: InternalRealtimeClientProtocol where Realtime.Channels.Channel.Proxied == Room.Channel
     associatedtype Room: AblyChat.InternalRoom
 
-    func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: InternalLogger) throws(InternalError) -> Room
+    func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger) throws(InternalError) -> Room
 }
 
 internal final class DefaultRoomFactory<Realtime: InternalRealtimeClientProtocol>: Sendable, RoomFactory {
     private let lifecycleManagerFactory = DefaultRoomLifecycleManagerFactory()
 
-    internal func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: InternalLogger) throws(InternalError) -> DefaultRoom<Realtime> {
+    internal func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger) throws(InternalError) -> DefaultRoom<Realtime> {
         try DefaultRoom(
             realtime: realtime,
             chatAPI: chatAPI,
@@ -258,9 +258,9 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol>: InternalRo
         }
     #endif
 
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
 
-    internal init(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: InternalLogger, lifecycleManagerFactory: any RoomLifecycleManagerFactory) throws(InternalError) {
+    internal init(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger, lifecycleManagerFactory: any RoomLifecycleManagerFactory) throws(InternalError) {
         self.realtime = realtime
         self.name = name
         self.options = options
@@ -376,7 +376,7 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol>: InternalRo
     // MARK: - Room status
 
     @discardableResult
-    internal func onStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> StatusSubscriptionProtocol {
+    internal func onStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> any StatusSubscriptionProtocol {
         lifecycleManager.onRoomStatusChange(callback)
     }
 
@@ -387,7 +387,7 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol>: InternalRo
     // MARK: - Discontinuities
 
     @discardableResult
-    internal func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> StatusSubscriptionProtocol {
+    internal func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> any StatusSubscriptionProtocol {
         lifecycleManager.onDiscontinuity(callback)
     }
 }

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -26,7 +26,7 @@ public protocol RoomReactions: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from `RoomReactionEvent` events.
      */
     @discardableResult
-    func subscribe(_ callback: @escaping @MainActor (RoomReactionEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(_ callback: @escaping @MainActor (RoomReactionEvent) -> Void) -> any SubscriptionProtocol
 }
 
 /// `AsyncSequence` variant of receiving room reactions.

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -78,7 +78,7 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
 
     internal nonisolated let clientOptions: ChatClientOptions
 
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let roomFactory: RoomFactory
 
     /// All the state that a `DefaultRooms` instance might hold for a given room name.
@@ -131,7 +131,7 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     /// The value for a given room name is the state that corresponds to that room name.
     private var roomStates: [String: RoomState] = [:]
 
-    internal init(realtime: RoomFactory.Realtime, clientOptions: ChatClientOptions, logger: InternalLogger, roomFactory: RoomFactory) {
+    internal init(realtime: RoomFactory.Realtime, clientOptions: ChatClientOptions, logger: any InternalLogger, roomFactory: RoomFactory) {
         self.realtime = realtime
         self.clientOptions = clientOptions
         self.logger = logger
@@ -157,7 +157,7 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
         private let operationWaitEventSubscriptions = SubscriptionStorage<OperationWaitEvent>()
 
         /// Returns a subscription which emits an event each time one operation is going to wait for another to complete.
-        internal func testsOnly_subscribeToOperationWaitEvents(_ callback: @escaping @MainActor (OperationWaitEvent) -> Void) -> SubscriptionProtocol {
+        internal func testsOnly_subscribeToOperationWaitEvents(_ callback: @escaping @MainActor (OperationWaitEvent) -> Void) -> any SubscriptionProtocol {
             operationWaitEventSubscriptions.create(callback)
         }
 

--- a/Sources/AblyChat/SubscriptionStorage.swift
+++ b/Sources/AblyChat/SubscriptionStorage.swift
@@ -13,7 +13,7 @@ internal class SubscriptionStorage<Element: Sendable> {
     private var subscriptions: [UUID: SubscriptionItem] = [:]
 
     /// Creates a subscription and adds it to the list managed by this `SubscriptionStorage` instance.
-    internal func create(_ callback: @escaping @MainActor (Element) -> Void) -> SubscriptionProtocol {
+    internal func create(_ callback: @escaping @MainActor (Element) -> Void) -> any SubscriptionProtocol {
         let id = UUID()
         let subscription = Subscription { [weak self] in
             self?.subscriptionDidTerminate(id: id)
@@ -54,7 +54,7 @@ internal class StatusSubscriptionStorage<Element: Sendable> {
     private var subscriptions: [UUID: SubscriptionItem] = [:]
 
     /// Creates a subscription and adds it to the list managed by this `SubscriptionStorage` instance.
-    internal func create(_ callback: @escaping @MainActor (Element) -> Void) -> StatusSubscriptionProtocol {
+    internal func create(_ callback: @escaping @MainActor (Element) -> Void) -> any StatusSubscriptionProtocol {
         let id = UUID()
         let statusSubscription = StatusSubscription { [weak self] in
             self?.subscriptionDidTerminate(id: id)

--- a/Sources/AblyChat/Typing.swift
+++ b/Sources/AblyChat/Typing.swift
@@ -17,7 +17,7 @@ public protocol Typing: AnyObject, Sendable {
      * - Returns: A subscription that can be used to unsubscribe from ``TypingEvent`` events.
      */
     @discardableResult
-    func subscribe(_ callback: @escaping @MainActor (TypingSetEvent) -> Void) -> SubscriptionProtocol
+    func subscribe(_ callback: @escaping @MainActor (TypingSetEvent) -> Void) -> any SubscriptionProtocol
 
     /**
      * Get the current typers, a set of clientIds.

--- a/Sources/AblyChat/TypingTimerManager.swift
+++ b/Sources/AblyChat/TypingTimerManager.swift
@@ -4,7 +4,7 @@ import Foundation
 internal final class TypingTimerManager<AnyClock: ClockProtocol>: TypingTimerManagerProtocol {
     private let heartbeatThrottle: TimeInterval
     private let gracePeriod: TimeInterval
-    private let logger: InternalLogger
+    private let logger: any InternalLogger
     private let clock: AnyClock
 
     /// Stores the CHA-T13b1 "is somebody typing" timers. Keys are clientID.
@@ -13,7 +13,7 @@ internal final class TypingTimerManager<AnyClock: ClockProtocol>: TypingTimerMan
     /// Stores the moment when the CHA-T4a4 heartbeat timer (which we use for deciding whether to publish another typing event for the current user) was started. If `nil`, then there is no active heartbeat timer.
     private var heartbeatTimerStartedAt: AnyClock.Instant?
 
-    internal init(heartbeatThrottle: TimeInterval, gracePeriod: TimeInterval, logger: InternalLogger, clock: AnyClock) {
+    internal init(heartbeatThrottle: TimeInterval, gracePeriod: TimeInterval, logger: any InternalLogger, clock: AnyClock) {
         self.heartbeatThrottle = heartbeatThrottle
         self.gracePeriod = gracePeriod
         self.logger = logger

--- a/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomLifecycleManagerTests.swift
@@ -34,7 +34,7 @@ struct DefaultRoomLifecycleManagerTests {
         forTestingWhatHappensWhenHasHasAttachedOnce hasAttachedOnce: Bool? = nil,
         forTestingWhatHappensWhenHasIsExplicitlyDetached isExplicitlyDetached: Bool? = nil,
         channel: MockRealtimeChannel? = nil,
-        clock: SimpleClock = MockSimpleClock(),
+        clock: any SimpleClock = MockSimpleClock(),
     ) -> DefaultRoomLifecycleManager {
         .init(
             testsOnly_roomStatus: roomStatus,
@@ -1015,7 +1015,7 @@ struct DefaultRoomLifecycleManagerTests {
         channelAttachOperation.complete(behavior: .completeAndChangeState(.failure(channelAttachError), newState: .failed))
 
         // Then: The call to `waitToBeAbleToPerformPresenceOperations(requestedByFeature:)` fails with a `roomInInvalidState` error with status code 500, whose cause is the error associated with the room status change
-        var caughtError: Error?
+        var caughtError: (any Error)?
         do {
             try await waitToBeAbleToPerformPresenceOperationsResult
         } catch {
@@ -1054,7 +1054,7 @@ struct DefaultRoomLifecycleManagerTests {
         // (Note: I wanted to use #expect(…, throws:) below, but for some reason it made the compiler _crash_! No idea why. So, gave up on that.)
 
         // When: `waitToBeAbleToPerformPresenceOperations(requestedByFeature:)` is called on the lifecycle manager
-        var caughtError: Error?
+        var caughtError: (any Error)?
         do {
             try await manager.waitToBeAbleToPerformPresenceOperations(requestedByFeature: .messages /* arbitrary */ )
         } catch {

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -43,7 +43,7 @@ struct DefaultRoomReactionsTests {
                 "name": reaction,
             ]
             message.version = .init(serial: "0")
-            message.extras = [String: String]() as ARTJsonCompatible
+            message.extras = [String: String]() as (any ARTJsonCompatible)
             return message
         }
 

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -371,7 +371,7 @@ struct DefaultRoomsTests {
         async let secondReleaseResult: Void = rooms.release(name: name)
 
         // Then: The pending call to `get(name:options:)` that is waiting for the “CHA-RC1f future” of the “Given” fails with a RoomReleasedBeforeOperationCompleted error
-        let roomGetError: Error?
+        let roomGetError: (any Error)?
         do {
             _ = try await fetchedRoom
             roomGetError = nil

--- a/Tests/AblyChatTests/JSONValueTests.swift
+++ b/Tests/AblyChatTests/JSONValueTests.swift
@@ -23,7 +23,7 @@ struct JSONValueTests {
         // null
         (ablyCocoaPresenceData: NSNull(), expectedResult: .null),
     ] as[(ablyCocoaPresenceData: Sendable, expectedResult: JSONValue?)])
-    func initWithAblyCocoaPresenceData(ablyCocoaData: Sendable, expectedResult: JSONValue?) {
+    func initWithAblyCocoaPresenceData(ablyCocoaData: any Sendable, expectedResult: JSONValue?) {
         #expect(JSONValue(ablyCocoaData: ablyCocoaData) == expectedResult)
     }
 
@@ -95,7 +95,7 @@ struct JSONValueTests {
         // null
         (value: .null, expectedResult: NSNull()),
     ] as[(value: JSONValue, expectedResult: Sendable)])
-    func toAblyCocoaData(value: JSONValue, expectedResult: Sendable) throws {
+    func toAblyCocoaData(value: JSONValue, expectedResult: any Sendable) throws {
         let resultAsNSObject = try #require(value.toAblyCocoaData as? NSObject)
         let expectedResultAsNSObject = try #require(expectedResult as? NSObject)
         #expect(resultAsNSObject == expectedResultAsNSObject)

--- a/Tests/AblyChatTests/Mocks/MockRoom.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoom.swift
@@ -65,12 +65,12 @@ class MockRoom: InternalRoom {
     private let _releaseCallsAsyncSequence: (stream: AsyncStream<Void>, continuation: AsyncStream<Void>.Continuation)
 
     @discardableResult
-    func onStatusChange(_: @escaping @MainActor (RoomStatusChange) -> Void) -> StatusSubscriptionProtocol {
+    func onStatusChange(_: @escaping @MainActor (RoomStatusChange) -> Void) -> any StatusSubscriptionProtocol {
         fatalError("Not implemented")
     }
 
     @discardableResult
-    func onDiscontinuity(_: @escaping @MainActor (DiscontinuityEvent) -> Void) -> StatusSubscriptionProtocol {
+    func onDiscontinuity(_: @escaping @MainActor (DiscontinuityEvent) -> Void) -> any StatusSubscriptionProtocol {
         fatalError("Not implemented")
     }
 

--- a/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomLifecycleManager.swift
@@ -75,12 +75,12 @@ class MockRoomLifecycleManager: RoomLifecycleManager {
     }
 
     @discardableResult
-    func onRoomStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> StatusSubscriptionProtocol {
+    func onRoomStatusChange(_ callback: @escaping @MainActor (RoomStatusChange) -> Void) -> any StatusSubscriptionProtocol {
         roomStatusSubscriptions.create(callback)
     }
 
     @discardableResult
-    func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> StatusSubscriptionProtocol {
+    func onDiscontinuity(_ callback: @escaping @MainActor (DiscontinuityEvent) -> Void) -> any StatusSubscriptionProtocol {
         discontinuitySubscriptions.create(callback)
     }
 


### PR DESCRIPTION
**Note: This PR is based on top of #362; please review that one first.**

`ExistentialAny` and `MemberImportVisibility`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Adopted Swift existential "any" across public/internal APIs (subscriptions, messages, presence, typing, reactions, room/connection status) and for logger/clock types — broadens allowed implementations; may require minor consumer type adjustments.

- Chores
  - Centralized Swift build settings and enabled upcoming Swift features across targets.

- Tests
  - Updated tests to match existential types and added minor imports.

- Style
  - Standardized type-erased protocol usage for logger/clock dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->