### PR TITLE
[ECO-5577] Update method names in line with Swift guidelines

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -224,7 +224,7 @@ struct ContentView: View {
 
                 try await room.attach()
                 try await showOccupancy(room: room)
-                try await room.presence.enter(data: ["status": "📱 Online"])
+                try await room.presence.enter(withData: ["status": "📱 Online"])
 
                 try await showMessages(room: room)
             } catch {
@@ -275,7 +275,7 @@ struct ContentView: View {
                 }
             }
         }
-        let previousMessages = try await subscription.historyBeforeSubscribe(.init())
+        let previousMessages = try await subscription.historyBeforeSubscribe(withParams: .init())
 
         for message in previousMessages.items {
             switch message.action {
@@ -387,7 +387,7 @@ struct ContentView: View {
         guard !newMessage.isEmpty else {
             return
         }
-        _ = try await room().messages.send(params: .init(text: newMessage))
+        _ = try await room().messages.send(withParams: .init(text: newMessage))
         newMessage = ""
     }
 
@@ -417,19 +417,19 @@ struct ContentView: View {
 
     func sendRoomReaction(_ reaction: String) {
         Task {
-            try await room().reactions.send(params: .init(name: reaction))
+            try await room().reactions.send(withParams: .init(name: reaction))
         }
     }
 
     func addMessageReaction(_ reaction: String, messageSerial: String) {
         Task {
-            try await room().messages.reactions.send(messageSerial: messageSerial, params: .init(name: reaction, type: .distinct))
+            try await room().messages.reactions.send(forMessageWithSerial: messageSerial, params: .init(name: reaction, type: .distinct))
         }
     }
 
     func deleteMessageReaction(_ reaction: String, messageSerial: String) {
         Task {
-            try await room().messages.reactions.delete(messageSerial: messageSerial, params: .init(name: reaction, type: .distinct))
+            try await room().messages.reactions.delete(forMessageWithSerial: messageSerial, params: .init(name: reaction, type: .distinct))
         }
     }
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -154,11 +154,11 @@ class MockMessages: Messages {
         )
     }
 
-    func history(options _: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    func history(withOptions _: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         MockMessagesPaginatedResult(clientID: clientID, roomName: roomName)
     }
 
-    func send(params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
+    func send(withParams params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
         let message = Message(
             serial: "\(Date().timeIntervalSince1970)",
             action: .create,
@@ -246,7 +246,7 @@ class MockMessageReactions: MessageReactions {
         self.roomName = roomName
     }
 
-    func send(messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo) {
+    func send(forMessageWithSerial messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo) {
         reactions.append(
             MessageReaction(
                 type: .distinct,
@@ -265,7 +265,7 @@ class MockMessageReactions: MessageReactions {
         )
     }
 
-    func delete(messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
+    func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         reactions.removeAll { reaction in
             reaction.messageSerial == messageSerial && reaction.name == params.name && reaction.clientID == clientID
         }
@@ -319,7 +319,7 @@ class MockRoomReactions: RoomReactions {
         self.roomName = roomName
     }
 
-    func send(params: SendReactionParams) async throws(ARTErrorInfo) {
+    func send(withParams params: SendReactionParams) async throws(ARTErrorInfo) {
         let reaction = RoomReaction(
             name: params.name,
             metadata: [:],
@@ -447,7 +447,7 @@ class MockPresence: Presence {
         }
     }
 
-    func get(params _: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
+    func get(withParams _: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,
@@ -458,7 +458,7 @@ class MockPresence: Presence {
         }
     }
 
-    func isUserPresent(clientID _: String) async throws(ARTErrorInfo) -> Bool {
+    func isUserPresent(withClientID _: String) async throws(ARTErrorInfo) -> Bool {
         fatalError("Not yet implemented")
     }
 
@@ -466,7 +466,7 @@ class MockPresence: Presence {
         try await enter(dataForEvent: nil)
     }
 
-    func enter(data: PresenceData) async throws(ARTErrorInfo) {
+    func enter(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await enter(dataForEvent: data)
     }
 
@@ -489,7 +489,7 @@ class MockPresence: Presence {
         try await update(dataForEvent: nil)
     }
 
-    func update(data: PresenceData) async throws(ARTErrorInfo) {
+    func update(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await update(dataForEvent: data)
     }
 
@@ -512,7 +512,7 @@ class MockPresence: Presence {
         try await leave(dataForEvent: nil)
     }
 
-    func leave(data: PresenceData) async throws(ARTErrorInfo) {
+    func leave(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await leave(dataForEvent: data)
     }
 

--- a/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
@@ -208,7 +208,7 @@ struct MockMessageSubscriptionResponse<PaginatedResult: AblyChat.PaginatedResult
     private let _unsubscribe: () -> Void
     private let previousMessages: @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult
 
-    func historyBeforeSubscribe(_ params: QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult {
+    func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult {
         try await previousMessages(params)
     }
 

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -19,7 +19,7 @@ internal final class DefaultMessageReactions: MessageReactions {
     }
 
     // (CHA-MR4) Users should be able to send a reaction to a message via the `send` method of the `MessagesReactions` object
-    internal func send(messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo) {
+    internal func send(forMessageWithSerial messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo) {
         do {
             var count = params.count
             if params.type == .multiple, params.count == nil {
@@ -40,7 +40,7 @@ internal final class DefaultMessageReactions: MessageReactions {
     }
 
     // (CHA-MR11) Users should be able to delete a reaction from a message via the `delete` method of the `MessagesReactions` object
-    internal func delete(messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
+    internal func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         let reactionType = params.type ?? options.defaultMessageReactionType
         if reactionType != .unique, params.name == nil {
             throw ARTErrorInfo(chatError: .unableDeleteReactionWithoutName(reactionType: reactionType.rawValue))

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -115,7 +115,7 @@ internal final class DefaultMessages: Messages {
     }
 
     // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
-    internal func history(options: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    internal func history(withOptions options: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         do {
             return try await chatAPI.getMessages(roomName: roomName, params: options)
         } catch {
@@ -123,7 +123,7 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal func send(params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
+    internal func send(withParams params: SendMessageParams) async throws(ARTErrorInfo) -> Message {
         do {
             return try await chatAPI.sendMessage(roomName: roomName, params: params)
         } catch {

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -42,7 +42,7 @@ internal final class DefaultPresence: Presence {
         }
     }
 
-    internal func get(params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
+    internal func get(withParams params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember] {
         do throws(InternalError) {
             logger.log(message: "Getting presence with params: \(params)", level: .debug)
 
@@ -68,7 +68,7 @@ internal final class DefaultPresence: Presence {
     }
 
     // (CHA-PR5) It must be possible to query if a given clientId is in the presence set.
-    internal func isUserPresent(clientID: String) async throws(ARTErrorInfo) -> Bool {
+    internal func isUserPresent(withClientID clientID: String) async throws(ARTErrorInfo) -> Bool {
         do throws(InternalError) {
             logger.log(message: "Checking if user is present with clientID: \(clientID)", level: .debug)
 
@@ -94,7 +94,7 @@ internal final class DefaultPresence: Presence {
         }
     }
 
-    internal func enter(data: PresenceData) async throws(ARTErrorInfo) {
+    internal func enter(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await enter(optionalData: data)
     }
 
@@ -126,7 +126,7 @@ internal final class DefaultPresence: Presence {
         }
     }
 
-    internal func update(data: PresenceData) async throws(ARTErrorInfo) {
+    internal func update(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await update(optionalData: data)
     }
 
@@ -158,7 +158,7 @@ internal final class DefaultPresence: Presence {
         }
     }
 
-    internal func leave(data: PresenceData) async throws(ARTErrorInfo) {
+    internal func leave(withData data: PresenceData) async throws(ARTErrorInfo) {
         try await leave(optionalData: data)
     }
 

--- a/Sources/AblyChat/DefaultRoomReactions.swift
+++ b/Sources/AblyChat/DefaultRoomReactions.swift
@@ -15,7 +15,7 @@ internal final class DefaultRoomReactions: RoomReactions {
 
     // (CHA-ER3) Ephemeral room reactions are sent to Ably via the Realtime connection via a send method.
     // (CHA-ER3d) Reactions are sent on the channel using a message in a particular format - see spec for format.
-    internal func send(params: SendReactionParams) async throws(ARTErrorInfo) {
+    internal func send(withParams params: SendReactionParams) async throws(ARTErrorInfo) {
         do {
             logger.log(message: "Sending reaction with params: \(params)", level: .debug)
 

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -19,7 +19,7 @@ public protocol MessageReactions: AnyObject, Sendable {
      *
      * - Note: It is possible to receive your own reaction via the reactions subscription before this method returns.
      */
-    func send(messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo)
+    func send(forMessageWithSerial messageSerial: String, params: SendMessageReactionParams) async throws(ARTErrorInfo)
 
     /**
      * Delete a message reaction.
@@ -28,7 +28,7 @@ public protocol MessageReactions: AnyObject, Sendable {
      *   - messageSerial: A serial of the message to remove the reaction from.
      *   - params: The type of reaction annotation and the specific reaction to remove. The reaction to remove is required for all types except ``MessageReactionType/unique``.
      */
-    func delete(messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo)
+    func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo)
 
     /**
      * Subscribe to message reaction summaries. Use this to keep message reaction counts up to date efficiently in the UI.

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -33,7 +33,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: A paginated result object that can be used to fetch more messages if available.
      */
-    func history(options: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
+    func history(withOptions options: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
 
     /**
      * Send a message in the chat room.
@@ -47,7 +47,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Note: It is possible to receive your own message via the messages subscription before this method returns.
      */
-    func send(params: SendMessageParams) async throws(ARTErrorInfo) -> Message
+    func send(withParams params: SendMessageParams) async throws(ARTErrorInfo) -> Message
 
     /**
      * Updates a message in the chat room.
@@ -391,7 +391,7 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
     }
 
     // swiftlint:disable:next missing_docs
-    public func getPreviousMessages(params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult {
+    public func getPreviousMessages(withParams params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult {
         try await getPreviousMessages(params)
     }
 

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -29,7 +29,7 @@ public protocol Presence: AnyObject, Sendable {
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func get(params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember]
+    func get(withParams params: PresenceParams) async throws(ARTErrorInfo) -> [PresenceMember]
 
     /**
      * Method to check if user with supplied clientId is online.
@@ -41,7 +41,7 @@ public protocol Presence: AnyObject, Sendable {
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func isUserPresent(clientID: String) async throws(ARTErrorInfo) -> Bool
+    func isUserPresent(withClientID clientID: String) async throws(ARTErrorInfo) -> Bool
 
     /**
      * Method to join room presence, will emit an enter event to all subscribers. Repeat calls will trigger more enter events.
@@ -51,7 +51,7 @@ public protocol Presence: AnyObject, Sendable {
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func enter(data: PresenceData) async throws(ARTErrorInfo)
+    func enter(withData data: PresenceData) async throws(ARTErrorInfo)
 
     /**
      * Method to update room presence, will emit an update event to all subscribers. If the user is not present, it will be treated as a join event.
@@ -61,7 +61,7 @@ public protocol Presence: AnyObject, Sendable {
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func update(data: PresenceData) async throws(ARTErrorInfo)
+    func update(withData data: PresenceData) async throws(ARTErrorInfo)
 
     /**
      * Method to leave room presence, will emit a leave event to all subscribers. If the user is not present, it will be treated as a no-op.
@@ -71,7 +71,7 @@ public protocol Presence: AnyObject, Sendable {
      *
      * - Throws: An `ARTErrorInfo`.
      */
-    func leave(data: PresenceData) async throws(ARTErrorInfo)
+    func leave(withData data: PresenceData) async throws(ARTErrorInfo)
 
     /**
      * Subscribes a given listener to a particular presence event in the chat room.

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -18,7 +18,7 @@ public protocol RoomReactions: AnyObject, Sendable {
      *
      * - Note: It is possible to receive your own reaction via the reactions subscription before this method returns.
      */
-    func send(params: SendReactionParams) async throws(ARTErrorInfo)
+    func send(withParams params: SendReactionParams) async throws(ARTErrorInfo)
 
     /**
      * Subscribes a given listener to the room reactions.

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -54,7 +54,7 @@ public protocol MessageSubscriptionResponse: Subscription, Sendable {
      *
      * - Returns: A paginated result of messages, in newest-to-oldest order.
      */
-    func historyBeforeSubscribe(_ params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
+    func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
 }
 
 internal struct DefaultSubscription: Subscription, Sendable {
@@ -91,7 +91,7 @@ internal struct DefaultMessageSubscriptionResponse: MessageSubscriptionResponse,
         _unsubscribe()
     }
 
-    internal func historyBeforeSubscribe(_ params: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    internal func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         do {
             let fromSerial = try await subscriptionStartSerial()
 

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -23,9 +23,9 @@ struct DefaultMessageReactionsTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let message = try await defaultMessages.send(params: .init(text: "a joke"))
-        try await defaultMessages.reactions.send(messageSerial: message.serial, params: .init(name: "😆", type: .multiple, count: 10))
-        try await defaultMessages.reactions.delete(messageSerial: message.serial, params: .init(name: "😆", type: .multiple))
+        let message = try await defaultMessages.send(withParams: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(forMessageWithSerial: message.serial, params: .init(name: "😆", type: .multiple, count: 10))
+        try await defaultMessages.reactions.delete(forMessageWithSerial: message.serial, params: .init(name: "😆", type: .multiple))
 
         // Then
         #expect(realtime.callRecorder.hasRecord(
@@ -70,7 +70,7 @@ struct DefaultMessageReactionsTests {
 
         let doIt = {
             // When
-            try await defaultMessages.reactions.send(messageSerial: "", params: .init(name: "😐", type: .distinct))
+            try await defaultMessages.reactions.send(forMessageWithSerial: "", params: .init(name: "😐", type: .distinct))
         }
         await #expect {
             try await doIt()
@@ -93,7 +93,7 @@ struct DefaultMessageReactionsTests {
 
         let doIt = {
             // When
-            try await defaultMessages.reactions.delete(messageSerial: "", params: .init(name: "😐", type: .distinct))
+            try await defaultMessages.reactions.delete(forMessageWithSerial: "", params: .init(name: "😐", type: .distinct))
         }
         await #expect {
             try await doIt()
@@ -345,8 +345,8 @@ struct DefaultMessageReactionsTests {
         let defaultMessages = room.messages
 
         // When
-        let message = try await defaultMessages.send(params: .init(text: "a joke"))
-        try await defaultMessages.reactions.send(messageSerial: message.serial, params: .init(name: "😆"))
+        let message = try await defaultMessages.send(withParams: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(forMessageWithSerial: message.serial, params: .init(name: "😆"))
 
         // Then
         #expect(realtime.callRecorder.hasRecord(
@@ -384,8 +384,8 @@ struct DefaultMessageReactionsTests {
         let defaultMessages = room.messages
 
         // When
-        let message = try await defaultMessages.send(params: .init(text: "a joke"))
-        try await defaultMessages.reactions.send(messageSerial: message.serial, params: .init(name: "😆"))
+        let message = try await defaultMessages.send(withParams: .init(text: "a joke"))
+        try await defaultMessages.reactions.send(forMessageWithSerial: message.serial, params: .init(name: "😆"))
 
         // Then
         #expect(realtime.callRecorder.hasRecord(

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -36,7 +36,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let sentMessage = try await defaultMessages.send(params: .init(text: "hey", metadata: ["key1": "val1"], headers: ["key2": "val2"]))
+        let sentMessage = try await defaultMessages.send(withParams: .init(text: "hey", metadata: ["key1": "val1"], headers: ["key2": "val2"]))
 
         // Then
         #expect(sentMessage.serial == "0")
@@ -160,7 +160,7 @@ struct DefaultMessagesTests {
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await defaultMessages.send(params: .init(text: "hey"))
+            _ = try await defaultMessages.send(withParams: .init(text: "hey"))
         }
         await #expect {
             try await doIt()
@@ -232,7 +232,7 @@ struct DefaultMessagesTests {
         )
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         // Then: subscription point is the current channelSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -259,7 +259,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHING
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -286,7 +286,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
@@ -301,7 +301,7 @@ struct DefaultMessagesTests {
             ARTChannelStateChange(current: .attached, previous: .detached, event: .attached, reason: nil, resumed: false),
         )
 
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -328,7 +328,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
@@ -340,7 +340,7 @@ struct DefaultMessagesTests {
             ARTChannelStateChange(current: .attached, previous: .attached, event: .update, reason: nil, resumed: false),
         )
 
-        _ = try await subscription.getPreviousMessages(params: .init())
+        _ = try await subscription.getPreviousMessages(withParams: .init())
 
         // Then: subscription point is the attachSerial of the realtime channel
         #expect(realtime.callRecorder.hasRecord(
@@ -368,7 +368,7 @@ struct DefaultMessagesTests {
 
         // When: subscription is added when the underlying realtime channel is ATTACHED
         let subscription = defaultMessages.subscribe()
-        let paginatedResult = try await subscription.getPreviousMessages(params: .init(orderBy: .oldestFirst)) // CHA-M5f, try to set unsupported direction
+        let paginatedResult = try await subscription.getPreviousMessages(withParams: .init(orderBy: .oldestFirst)) // CHA-M5f, try to set unsupported direction
 
         let requestParams = try #require(realtime.requestArguments.first?.params)
 
@@ -410,7 +410,7 @@ struct DefaultMessagesTests {
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await subscription.getPreviousMessages(params: .init())
+            _ = try await subscription.getPreviousMessages(withParams: .init())
         }
         // Then
         await #expect {
@@ -436,7 +436,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let paginatedResult = try await defaultMessages.history(options: .init())
+        let paginatedResult = try await defaultMessages.history(withOptions: .init())
 
         // Then
         // CHA-M6a: The method return a PaginatedResult containing messages
@@ -467,7 +467,7 @@ struct DefaultMessagesTests {
         // When
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await defaultMessages.history(options: .init())
+            _ = try await defaultMessages.history(withOptions: .init())
         }
         // Then
         await #expect {

--- a/Tests/AblyChatTests/DefaultPresenceTests.swift
+++ b/Tests/AblyChatTests/DefaultPresenceTests.swift
@@ -22,7 +22,7 @@ struct DefaultPresenceTests {
         )
 
         // When
-        try await defaultPresence.enter(data: ["status": "Online"])
+        try await defaultPresence.enter(withData: ["status": "Online"])
 
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
@@ -167,7 +167,7 @@ struct DefaultPresenceTests {
             options: .init(),
         )
         // When
-        try await defaultPresence.update(data: ["status": "Online"])
+        try await defaultPresence.update(withData: ["status": "Online"])
 
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
@@ -287,7 +287,7 @@ struct DefaultPresenceTests {
         )
 
         // When
-        try await defaultPresence.leave(data: ["status": "Online"])
+        try await defaultPresence.leave(withData: ["status": "Online"])
 
         // Then
         #expect(channel.presence.callRecorder.hasRecord(
@@ -315,7 +315,7 @@ struct DefaultPresenceTests {
         )
 
         // When
-        _ = try await defaultPresence.isUserPresent(clientID: "client1")
+        _ = try await defaultPresence.isUserPresent(withClientID: "client1")
 
         // Then
         #expect(channel.presence.callRecorder.hasRecord(

--- a/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomReactionsTests.swift
@@ -21,7 +21,7 @@ struct DefaultRoomReactionsTests {
         )
 
         // When
-        try await defaultRoomReactions.send(params: sendReactionParams)
+        try await defaultRoomReactions.send(withParams: sendReactionParams)
 
         // Then
         #expect(channel.publishedMessages.last?.name == RoomReactionEvents.reaction.rawValue)

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -111,7 +111,7 @@ struct IntegrationTests {
 
         // (3) Send the message
         let txMessageBeforeRxSubscribe = try await txRoom.messages.send(
-            params: .init(
+            withParams: .init(
                 text: "Hello from txRoom, before rxRoom subscribe",
             ),
         )
@@ -125,7 +125,7 @@ struct IntegrationTests {
 
         // (6) Now that we're subscribed to messages, send a message on the other client and check that we receive it on the subscription
         let txMessageAfterRxSubscribe = try await txRoom.messages.send(
-            params: .init(
+            withParams: .init(
                 text: "Hello from txRoom, after rxRoom subscribe",
                 metadata: ["someMetadataKey": 123, "someOtherMetadataKey": "foo"],
                 headers: ["someHeadersKey": 456, "someOtherHeadersKey": "bar"],
@@ -140,10 +140,10 @@ struct IntegrationTests {
 
         let rxMessageReactionsSubscription = rxRoom.messages.reactions.subscribe()
 
-        try await txRoom.messages.reactions.send(messageSerial: messageToReact.serial, params: .init(name: "👍"))
-        try await txRoom.messages.reactions.send(messageSerial: messageToReact.serial, params: .init(name: "🎉"))
-        try await txRoom.messages.reactions.delete(messageSerial: messageToReact.serial, params: .init(name: "👍"))
-        try await txRoom.messages.reactions.delete(messageSerial: messageToReact.serial, params: .init(name: "🎉"))
+        try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
+        try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
+        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
+        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
 
         var reactionSummaryEvents = [MessageReactionSummaryEvent]()
 
@@ -188,9 +188,9 @@ struct IntegrationTests {
 
         let rxMessageRawReactionsSubscription = rxRoom.messages.reactions.subscribeRaw()
 
-        try await txRoom.messages.reactions.send(messageSerial: messageToReact.serial, params: .init(name: "🔥"))
-        try await txRoom.messages.reactions.send(messageSerial: messageToReact.serial, params: .init(name: "😆"))
-        try await txRoom.messages.reactions.delete(messageSerial: messageToReact.serial, params: .init(name: "😆")) // not deleting 🔥 to check it later in history request
+        try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "🔥"))
+        try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "😆"))
+        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "😆")) // not deleting 🔥 to check it later in history request
 
         var reactionRawEvents = [MessageReactionRawEvent]()
 
@@ -221,7 +221,7 @@ struct IntegrationTests {
         /*
          TODO: This line should just be
 
-         let messages = try await rxMessageSubscription.getPreviousMessages(params: .init())
+         let messages = try await rxMessageSubscription.getPreviousMessages(withParams: .init())
 
          but sometimes `messages.items` is coming back empty. Andy said in
          https://ably-real-time.slack.com/archives/C03JDBVM5MY/p1733220395208909
@@ -239,7 +239,7 @@ struct IntegrationTests {
          */
         let rxMessagesHistory = try await {
             while true {
-                let messages = try await rxMessageSubscription.getPreviousMessages(params: .init())
+                let messages = try await rxMessageSubscription.getPreviousMessages(withParams: .init())
                 if !messages.items.isEmpty {
                     return messages
                 }
@@ -323,7 +323,7 @@ struct IntegrationTests {
 
         // (2) Now that we're subscribed to reactions, send a reaction on the other client and check that we receive it on the subscription
         try await txRoom.reactions.send(
-            params: .init(
+            withParams: .init(
                 name: "heart",
                 metadata: ["someMetadataKey": 123, "someOtherMetadataKey": "foo"],
                 headers: ["someHeadersKey": 456, "someOtherHeadersKey": "bar"],
@@ -380,7 +380,7 @@ struct IntegrationTests {
         let rxPresenceSubscription = rxRoom.presence.subscribe(events: [.enter, .leave, .update])
 
         // (2) Send `.enter` presence event with custom data on the other client and check that we receive it on the subscription
-        try await txRoom.presence.enter(data: ["randomData": "randomValue"])
+        try await txRoom.presence.enter(withData: ["randomData": "randomValue"])
         let rxPresenceEnterTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceEnterTxEvent.type == .enter)
         #expect(rxPresenceEnterTxEvent.member.data == ["randomData": "randomValue"])
@@ -391,31 +391,31 @@ struct IntegrationTests {
         #expect(rxPresenceMembers[0].data == ["randomData": "randomValue"])
 
         // (4) Send `.update` presence event with custom data on the other client and check that we receive it on the subscription
-        try await txRoom.presence.update(data: ["randomData": "randomValue"])
+        try await txRoom.presence.update(withData: ["randomData": "randomValue"])
         let rxPresenceUpdateTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceUpdateTxEvent.type == .update)
         #expect(rxPresenceUpdateTxEvent.member.data == ["randomData": "randomValue"])
 
         // (5) Send `.leave` presence event with custom data on the other client and check that we receive it on the subscription
-        try await txRoom.presence.leave(data: ["randomData": "randomValue"])
+        try await txRoom.presence.leave(withData: ["randomData": "randomValue"])
         let rxPresenceLeaveTxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceLeaveTxEvent.type == .leave)
         #expect(rxPresenceLeaveTxEvent.member.data == ["randomData": "randomValue"])
 
         // (6) Send `.enter` presence event with custom data on our client and check that we receive it on the subscription
-        try await txRoom.presence.enter(data: ["randomData": "randomValue"])
+        try await txRoom.presence.enter(withData: ["randomData": "randomValue"])
         let rxPresenceEnterRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceEnterRxEvent.type == .enter)
         #expect(rxPresenceEnterRxEvent.member.data == ["randomData": "randomValue"])
 
         // (7) Send `.update` presence event with custom data on our client and check that we receive it on the subscription
-        try await txRoom.presence.update(data: ["randomData": "randomValue"])
+        try await txRoom.presence.update(withData: ["randomData": "randomValue"])
         let rxPresenceUpdateRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceUpdateRxEvent.type == .update)
         #expect(rxPresenceUpdateRxEvent.member.data == ["randomData": "randomValue"])
 
         // (8) Send `.leave` presence event with custom data on our client and check that we receive it on the subscription
-        try await txRoom.presence.leave(data: ["randomData": "randomValue"])
+        try await txRoom.presence.leave(withData: ["randomData": "randomValue"])
         let rxPresenceLeaveRxEvent = try #require(await rxPresenceSubscription.first { @Sendable _ in true })
         #expect(rxPresenceLeaveRxEvent.type == .leave)
         #expect(rxPresenceLeaveRxEvent.member.data == ["randomData": "randomValue"])

--- a/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionAsyncSequenceTests.swift
@@ -52,7 +52,7 @@ struct MessageSubscriptionAsyncSequenceTests {
         let mockPaginatedResult = MockPaginatedResult<Message>()
         let subscription = MessageSubscriptionAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
-        let result = try await subscription.getPreviousMessages(params: .init())
+        let result = try await subscription.getPreviousMessages(withParams: .init())
         #expect(result === mockPaginatedResult)
     }
 }


### PR DESCRIPTION
See https://www.swift.org/documentation/api-design-guidelines/, in particular "Prefer method and function names that make use sites form grammatical English phrases".

The "omit needless words" guideline is a bit harder to interpret and I wonder whether, under that guideline, things like `send(withParams params: SendMessageParams)` should be `with params: SendMessageParams` but honestly I don't know how understandable that is, especially when you use implicit `.init(…)` to create the argument. I think better to err on the side of caution and being a bit more verbose?

Have renamed:
- `Messages`:
	- `history(options: QueryOptions)` to `history(withOptions options: QueryOptions)`
	- `send(params: SendMessageParams)` to `send(withParams params: SendMessageParams)`
- `MessageSubscriptionAsyncSequence`:
	- `getPreviousMessages(params: QueryOptions)` to `getPreviousMessages(withParams params: QueryOptions)`
- `MessageReactions`:
	- `send(messageSerial: String, params: SendMessageReactionParams)` to `send(forMessageWithSerial messageSerial: String, params: SendMessageReactionParams)`
	- `delete(messageSerial: String, params: SendMessageReactionParams)` to `delete(forMessageWithSerial messageSerial: String, params: SendMessageReactionParams)`
- `Presence`:
	- `get(params: PresenceParams)` to `get(withParams params: PresenceParams)`
	- `isUserPresent(clientID: String)` to `isUserPresent(withClientID clientID: String)`
	- `enter(data: PresenceData)` to `enter(withData data: PresenceData)`; ditto for `update`, `leave`
- `RoomReactions`:
	- `send(params: SendReactionParams)` to `send(withParams params: SendReactionParams)`
- `MessageSubscriptionResponse`:
	- `historyBeforeSubscribe(_ params: QueryOptions)` to `historyBeforeSubscribe(withParams params: QueryOptions)`

Have not touched Messages' `update` or `delete` methods yet because their signature seems completely inconsistent with that of JS; need to look into it further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized API parameter labels (withParams/withData/withOptions) across messages, reactions, presence, and subscriptions.
  - Renamed reaction methods to use forMessageWithSerial for clarity.
  - Call sites must update to the new labeled signatures.

- Bug Fixes
  - Multiple reaction sends now default count to 1 when unspecified.

- Tests
  - Updated all tests to use the new labeled APIs (send, history, presence, reactions, getPreviousMessages).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->