### PR TITLE
[ECO-5577] Rename `QueryOptions` to `HistoryParams`

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -154,7 +154,7 @@ class MockMessages: Messages {
         )
     }
 
-    func history(withOptions _: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    func history(withParams _: HistoryParams) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         MockMessagesPaginatedResult(clientID: clientID, roomName: roomName)
     }
 

--- a/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
+++ b/Example/AblyChatExample/Mocks/MockSubscriptionStorage.swift
@@ -127,7 +127,7 @@ class MockMessageSubscriptionStorage<Element: Sendable, PaginatedResult: AblyCha
 
         init(
             randomElement: @escaping @MainActor @Sendable () -> Element,
-            previousMessages: @escaping @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult,
+            previousMessages: @escaping @MainActor @Sendable (HistoryParams) async throws(ARTErrorInfo) -> PaginatedResult,
             interval: @escaping @MainActor @Sendable () -> Double,
             callback: @escaping @MainActor (Element) -> Void,
             onTerminate: @escaping () -> Void,
@@ -152,7 +152,7 @@ class MockMessageSubscriptionStorage<Element: Sendable, PaginatedResult: AblyCha
 
     func create(
         randomElement: @escaping @MainActor @Sendable () -> Element,
-        previousMessages: @escaping @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult,
+        previousMessages: @escaping @MainActor @Sendable (HistoryParams) async throws(ARTErrorInfo) -> PaginatedResult,
         interval: @autoclosure @escaping @MainActor @Sendable () -> Double,
         callback: @escaping @MainActor (Element) -> Void,
     ) -> some MessageSubscriptionResponse {
@@ -206,9 +206,9 @@ struct MockStatusSubscription: StatusSubscription {
 
 struct MockMessageSubscriptionResponse<PaginatedResult: AblyChat.PaginatedResult<Message>>: MessageSubscriptionResponse {
     private let _unsubscribe: () -> Void
-    private let previousMessages: @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult
+    private let previousMessages: @MainActor @Sendable (HistoryParams) async throws(ARTErrorInfo) -> PaginatedResult
 
-    func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult {
+    func historyBeforeSubscribe(withParams params: HistoryParams) async throws(ARTErrorInfo) -> PaginatedResult {
         try await previousMessages(params)
     }
 
@@ -217,7 +217,7 @@ struct MockMessageSubscriptionResponse<PaginatedResult: AblyChat.PaginatedResult
     }
 
     init(
-        previousMessages: @escaping @MainActor @Sendable (QueryOptions) async throws(ARTErrorInfo) -> PaginatedResult,
+        previousMessages: @escaping @MainActor @Sendable (HistoryParams) async throws(ARTErrorInfo) -> PaginatedResult,
         unsubscribe: @MainActor @Sendable @escaping () -> Void,
     ) {
         self.previousMessages = previousMessages

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -16,7 +16,7 @@ internal final class ChatAPI {
     }
 
     // (CHA-M6) Messages should be queryable from a paginated REST API.
-    internal func getMessages(roomName: String, params: QueryOptions) async throws(InternalError) -> some PaginatedResult<Message> {
+    internal func getMessages(roomName: String, params: HistoryParams) async throws(InternalError) -> some PaginatedResult<Message> {
         let endpoint = "\(apiVersionV4)/rooms/\(roomName)/messages"
         return try await makePaginatedRequest(endpoint, params: params.asQueryItems())
     }

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -115,9 +115,9 @@ internal final class DefaultMessages: Messages {
     }
 
     // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
-    internal func history(withOptions options: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    internal func history(withParams params: HistoryParams) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         do {
-            return try await chatAPI.getMessages(roomName: roomName, params: options)
+            return try await chatAPI.getMessages(roomName: roomName, params: params)
         } catch {
             throw error.toARTErrorInfo()
         }

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -29,11 +29,11 @@ public protocol Messages: AnyObject, Sendable {
      * Get messages that have been previously sent to the chat room, based on the provided options.
      *
      * - Parameters:
-     *   - options: Options for the query.
+     *   - params: Parameters for the query.
      *
      * - Returns: A paginated result object that can be used to fetch more messages if available.
      */
-    func history(withOptions options: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
+    func history(withParams params: HistoryParams) async throws(ARTErrorInfo) -> HistoryResult
 
     /**
      * Send a message in the chat room.
@@ -230,7 +230,7 @@ public struct DeleteMessageParams: Sendable {
 /**
  * Options for querying messages in a chat room.
  */
-public struct QueryOptions: Sendable {
+public struct HistoryParams: Sendable {
     // swiftlint:disable:next missing_docs
     public enum OrderBy: Sendable {
         // swiftlint:disable:next missing_docs
@@ -274,7 +274,7 @@ public struct QueryOptions: Sendable {
     internal var fromSerial: String?
 
     // swiftlint:disable:next missing_docs
-    public init(start: Date? = nil, end: Date? = nil, limit: Int? = nil, orderBy: QueryOptions.OrderBy? = nil) {
+    public init(start: Date? = nil, end: Date? = nil, limit: Int? = nil, orderBy: HistoryParams.OrderBy? = nil) {
         self.start = start
         self.end = end
         self.limit = limit
@@ -282,7 +282,7 @@ public struct QueryOptions: Sendable {
     }
 }
 
-internal extension QueryOptions {
+internal extension HistoryParams {
     // Same as `ARTDataQuery.asQueryItems` from ably-cocoa.
     func asQueryItems() -> [String: String] {
         var dict: [String: String] = [:]
@@ -363,12 +363,12 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
     private let subscription: SubscriptionAsyncSequence<Element>
 
     // can be set by either initialiser
-    private let getPreviousMessages: @Sendable (QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
+    private let getPreviousMessages: @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult
 
     // used internally
     internal init(
         bufferingPolicy: BufferingPolicy,
-        getPreviousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> HistoryResult,
+        getPreviousMessages: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult,
     ) {
         subscription = .init(bufferingPolicy: bufferingPolicy)
         self.getPreviousMessages = getPreviousMessages
@@ -376,7 +376,7 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
 
     // used for testing
     // swiftlint:disable:next missing_docs
-    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockGetPreviousMessages: @escaping @Sendable (QueryOptions) async throws(ARTErrorInfo) -> HistoryResult) where Underlying.Element == Element {
+    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockGetPreviousMessages: @escaping @Sendable (HistoryParams) async throws(ARTErrorInfo) -> HistoryResult) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
         getPreviousMessages = mockGetPreviousMessages
     }
@@ -391,7 +391,7 @@ public final class MessageSubscriptionAsyncSequence<HistoryResult: PaginatedResu
     }
 
     // swiftlint:disable:next missing_docs
-    public func getPreviousMessages(withParams params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult {
+    public func getPreviousMessages(withParams params: HistoryParams) async throws(ARTErrorInfo) -> HistoryResult {
         try await getPreviousMessages(params)
     }
 

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -50,11 +50,11 @@ public protocol MessageSubscriptionResponse: Subscription, Sendable {
      * fill any gaps in the message history.
      *
      * - Parameters:
-     *    - params: Options for the history query.
+     *    - params: Parameters for the history query.
      *
      * - Returns: A paginated result of messages, in newest-to-oldest order.
      */
-    func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> HistoryResult
+    func historyBeforeSubscribe(withParams params: HistoryParams) async throws(ARTErrorInfo) -> HistoryResult
 }
 
 internal struct DefaultSubscription: Subscription, Sendable {
@@ -91,7 +91,7 @@ internal struct DefaultMessageSubscriptionResponse: MessageSubscriptionResponse,
         _unsubscribe()
     }
 
-    internal func historyBeforeSubscribe(withParams params: QueryOptions) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
+    internal func historyBeforeSubscribe(withParams params: HistoryParams) async throws(ARTErrorInfo) -> some PaginatedResult<Message> {
         do {
             let fromSerial = try await subscriptionStartSerial()
 

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -436,7 +436,7 @@ struct DefaultMessagesTests {
         let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", clientID: "clientId", logger: TestLogger())
 
         // When
-        let paginatedResult = try await defaultMessages.history(withOptions: .init())
+        let paginatedResult = try await defaultMessages.history(withParams: .init())
 
         // Then
         // CHA-M6a: The method return a PaginatedResult containing messages
@@ -467,7 +467,7 @@ struct DefaultMessagesTests {
         // When
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            _ = try await defaultMessages.history(withOptions: .init())
+            _ = try await defaultMessages.history(withParams: .init())
         }
         // Then
         await #expect {


### PR DESCRIPTION
As in https://github.com/ably/ably-chat-js/pull/657/. And accordingly rename `Messages.history(withOptions:)` to `history(withParams:)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Renamed the history query type from QueryOptions to HistoryParams across messaging APIs and updated related method labels (withOptions → withParams / getPreviousMessages → historyBeforeSubscribe). Public behavior, endpoints, and results unchanged; update integrations to use HistoryParams.

- Tests
  - Updated and renamed tests to align with the new HistoryParams type and the withParams/historyBeforeSubscribe labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->