### PR TITLE
refactor: remove rooms.clientOptions

### DIFF
--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -116,7 +116,7 @@ public class ChatClient: ChatClientProtocol {
 
         logger = DefaultInternalLogger(logHandler: self.clientOptions.logHandler, logLevel: self.clientOptions.logLevel)
         let roomFactory = DefaultRoomFactory<InternalRealtimeClientAdapter<ARTWrapperSDKProxyRealtime>>()
-        _rooms = DefaultRooms(realtime: internalRealtime, clientOptions: self.clientOptions, logger: logger, roomFactory: roomFactory)
+        _rooms = DefaultRooms(realtime: internalRealtime, logger: logger, roomFactory: roomFactory)
         _connection = DefaultConnection(realtime: internalRealtime)
     }
 

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -52,13 +52,6 @@ public protocol Rooms<Channel>: AnyObject, Sendable {
      *   - name: The name of the room.
      */
     func release(name: String) async
-
-    /**
-     * Get the client options used to create the chat instance.
-     *
-     * - Returns: ``ClientOptions`` object.
-     */
-    var clientOptions: ChatClientOptions { get }
 }
 
 // swiftlint:disable:next missing_docs
@@ -79,8 +72,6 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
             realtime
         }
     #endif
-
-    internal let clientOptions: ChatClientOptions
 
     private let logger: any InternalLogger
     private let roomFactory: RoomFactory
@@ -135,9 +126,8 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     /// The value for a given room name is the state that corresponds to that room name.
     private var roomStates: [String: RoomState] = [:]
 
-    internal init(realtime: RoomFactory.Realtime, clientOptions: ChatClientOptions, logger: any InternalLogger, roomFactory: RoomFactory) {
+    internal init(realtime: RoomFactory.Realtime, logger: any InternalLogger, roomFactory: RoomFactory) {
         self.realtime = realtime
-        self.clientOptions = clientOptions
         self.logger = logger
         self.roomFactory = roomFactory
         chatAPI = ChatAPI(realtime: realtime)

--- a/Tests/AblyChatTests/ChatClientTests.swift
+++ b/Tests/AblyChatTests/ChatClientTests.swift
@@ -104,13 +104,12 @@ struct ChatClientTests {
             internalRealtimeClientFactory: internalRealtimeClientFactory,
         )
 
-        // Then: Its `rooms` property returns an instance of DefaultRooms with the wrapper SDK proxy realtime client and same client options
+        // Then: Its `rooms` property returns an instance of DefaultRooms with the wrapper SDK proxy realtime client
         #expect(internalRealtimeClientFactory.createInternalRealtimeClientArgument === proxyClient)
 
         let rooms = client.rooms
 
         let defaultRooms = try #require(rooms as? DefaultRooms<DefaultRoomFactory<InternalRealtimeClientAdapter<ARTWrapperSDKProxyRealtime>>>)
         #expect(defaultRooms.testsOnly_realtime === internalRealtime)
-        #expect(defaultRooms.clientOptions.isEqualForTestPurposes(options))
     }
 }

--- a/Tests/AblyChatTests/DefaultRoomsTests.swift
+++ b/Tests/AblyChatTests/DefaultRoomsTests.swift
@@ -42,7 +42,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options)
         let roomFactory = MockRoomFactory(room: roomToReturn)
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         // When: get(name:) is called
         let name = "basketball"
@@ -66,7 +66,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options)
         let roomFactory = MockRoomFactory(room: roomToReturn)
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         // When: get(name:options:) is called
         let name = "basketball"
@@ -93,7 +93,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options)
         let roomFactory = MockRoomFactory(room: roomToReturn)
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         let name = "basketball"
         let firstRoom = try await rooms.get(name: name, options: options)
@@ -119,7 +119,7 @@ struct DefaultRoomsTests {
         let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
 
         let roomFactory = MockRoomFactory(room: roomToReturn)
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         let name = "basketball"
 
@@ -164,7 +164,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
 
         let roomToReturn = MockRoom(options: options)
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let name = "basketball"
         _ = try await rooms.get(name: name, options: options)
@@ -196,7 +196,7 @@ struct DefaultRoomsTests {
         let roomReleaseOperation = SignallableReleaseOperation()
         let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
 
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let name = "basketball"
 
@@ -245,7 +245,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
 
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let name = "basketball"
 
@@ -285,7 +285,7 @@ struct DefaultRoomsTests {
             .init(name: "basketball::$chat"),
         ]))
         let roomFactory = MockRoomFactory()
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         // When: `release(name:)` is called with this room name
         // Then: The call to `release(name:)` completes (this is as much as I can do to test the spec’s “no-op”; i.e. check it doesn’t seem to wait for anything or have any obvious side effects)
@@ -305,7 +305,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
 
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let name = "basketball"
 
@@ -347,7 +347,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
 
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: MockRoomFactory(room: roomToReturn))
 
         let name = "basketball"
 
@@ -401,7 +401,7 @@ struct DefaultRoomsTests {
         let options = RoomOptions()
         let hasExistingRoomAtMomentRoomReleaseCalledStreamComponents = AsyncStream.makeStream(of: Bool.self)
         let roomFactory = MockRoomFactory()
-        let rooms = DefaultRooms(realtime: realtime, clientOptions: .init(), logger: TestLogger(), roomFactory: roomFactory)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
 
         let name = "basketball"
 


### PR DESCRIPTION
Not relevant at this level.

[CHA-1202]

[CHA-1202]: https://ably.atlassian.net/browse/CHA-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified room management setup by removing the need to pass separate client configuration during initialization. Initialization now requires fewer arguments, streamlining setup and reducing coupling. No runtime behavior changes expected.
- Tests
  - Updated tests to align with the simplified initializer and removed assertions tied to the old client-configuration parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->