### PR TITLE
messages: return the chat message directly from the server

### DIFF
--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -31,6 +31,7 @@ struct ChatAPITests {
     }
 
     // @spec CHA-M3a
+    // @spec CHA-M3a1
     @Test
     func sendMessage_returnsMessage() async throws {
         // Given
@@ -51,7 +52,7 @@ struct ChatAPITests {
             text: "hello",
             metadata: [:],
             headers: [:],
-            version: .init(serial: "3446456", timestamp: Date(timeIntervalSince1970: 1_631_840_000), clientID: "mockClientId"),
+            version: .init(serial: "3446456", timestamp: Date(timeIntervalSince1970: 1_631_840_000)),
             timestamp: Date(timeIntervalSince1970: 1_631_840_000),
         )
         #expect(message == expectedMessage)

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -19,12 +19,14 @@ struct DefaultMessagesTests {
                         "serial": "0",
                         "version": [
                             "serial": "0",
-                            "timestamp": 1_631_840_030_000,
+                            "timestamp": 1_631_840_000_000,
                         ],
                         "metadata": ["key1": "val1"],
                         "headers": ["key2": "val2"],
                         "timestamp": 1_631_840_000_000,
                         "text": "hey",
+                        "clientId": "clientId",
+                        "action": "message.create",
                     ],
                 ],
                 statusCode: 200,
@@ -42,9 +44,12 @@ struct DefaultMessagesTests {
         #expect(sentMessage.serial == "0")
         #expect(sentMessage.action == .create)
         #expect(sentMessage.text == "hey")
+        #expect(sentMessage.clientID == "clientId")
         #expect(sentMessage.version.serial == "0")
+        #expect(sentMessage.version.timestamp == Date(timeIntervalSince1970: 1_631_840_000_000 / 1000))
         #expect(sentMessage.metadata == ["key1": "val1"])
         #expect(sentMessage.headers == ["key2": "val2"])
+        #expect(sentMessage.timestamp == Date(timeIntervalSince1970: 1_631_840_000_000 / 1000))
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
             arguments: ["method": "POST", "path": "/chat/v4/rooms/basketball/messages", "body": ["text": "hey", "metadata": ["key1": "val1"], "headers": ["key2": "val2"]], "params": [:], "headers": [:]],
@@ -67,9 +72,14 @@ struct DefaultMessagesTests {
                             "metadata": ["key": "val"],
                             "description": "add exclamation",
                             "timestamp": 1_631_840_030_000,
+                            "clientId": "clientId2",
                         ],
                         "timestamp": 1_631_840_000_000,
-                        "text": "\(text)",
+                        "text": "hey!",
+                        "clientId": "clientId",
+                        "action": "message.update",
+                        "metadata": [:],
+                        "headers": [:],
                     ],
                 ],
                 statusCode: 200,
@@ -91,9 +101,13 @@ struct DefaultMessagesTests {
         #expect(updatedMessage.serial == "0")
         #expect(updatedMessage.action == .update)
         #expect(updatedMessage.text == "hey!")
+        #expect(updatedMessage.clientID == "clientId")
         #expect(updatedMessage.version.serial == "1")
+        #expect(updatedMessage.version.timestamp == Date(timeIntervalSince1970: 1_631_840_030_000 / 1000))
         #expect(updatedMessage.version.metadata == ["key": "val"])
         #expect(updatedMessage.version.description == "add exclamation")
+        #expect(updatedMessage.version.clientID == "clientId2")
+        #expect(updatedMessage.timestamp == Date(timeIntervalSince1970: 1_631_840_000_000 / 1000))
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
             arguments: ["method": "PUT", "path": "/chat/v4/rooms/basketball/messages/\(sentMessage.serial)", "body": ["message": ["text": "hey!", "metadata": [:], "headers": [:]], "description": "add exclamation", "metadata": ["key": "val"]], "params": [:], "headers": [:]],
@@ -115,9 +129,13 @@ struct DefaultMessagesTests {
                         "version": [
                             "serial": "1",
                             "timestamp": 1_631_840_030_000,
+                            "clientId": "clientId2",
                         ],
                         "timestamp": 1_631_840_000_000,
                         "text": "",
+                        "clientId": "clientId",
+                        "metadata": [:],
+                        "headers": [:],
                     ],
                 ],
                 statusCode: 200,
@@ -136,10 +154,13 @@ struct DefaultMessagesTests {
         // Then
         #expect(deletedMessage.serial == "0")
         #expect(deletedMessage.version.serial == "1")
+        #expect(deletedMessage.version.timestamp == Date(timeIntervalSince1970: 1_631_840_030_000 / 1000))
+        #expect(deletedMessage.version.clientID == "clientId2")
         #expect(deletedMessage.action == .delete)
         #expect(deletedMessage.text.isEmpty)
         #expect(deletedMessage.headers.isEmpty)
         #expect(deletedMessage.metadata.isEmpty)
+        #expect(deletedMessage.timestamp == Date(timeIntervalSince1970: 1_631_840_000_000 / 1000))
         #expect(realtime.callRecorder.hasRecord(
             matching: "request(_:path:params:body:headers:)",
             arguments: ["method": "POST", "path": "/chat/v4/rooms/basketball/messages/\(sentMessage.serial)/delete", "body": [:], "params": [:], "headers": [:]],

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -113,6 +113,8 @@ struct IntegrationTests {
         let txMessageBeforeRxSubscribe = try await txRoom.messages.send(
             withParams: .init(
                 text: "Hello from txRoom, before rxRoom subscribe",
+                metadata: ["someMetadataKey": 123, "someOtherMetadataKey": "foo"],
+                headers: ["someHeadersKey": 456, "someOtherHeadersKey": "bar"],
             ),
         )
 

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -58,13 +58,17 @@ extension MockHTTPPaginatedResponse {
     static let successSendMessage = MockHTTPPaginatedResponse(
         items: [
             [
+                "clientId": "mockClientId",
                 "serial": "3446456",
+                "action": "message.create",
+                "text": "hello",
+                "metadata": [:],
+                "headers": [:],
                 "version": [
                     "serial": "3446456",
+                    "timestamp": 1_631_840_000_000,
                 ],
                 "timestamp": 1_631_840_000_000,
-                "createdAt": 1_631_840_000_000,
-                "text": "hello",
             ],
         ],
         statusCode: 200,


### PR DESCRIPTION
Update `messages.send`, update and delete to directly use the server response instead of mapping local properties.

[CHA-1197]

Spec: https://github.com/ably/specification/pull/388

[CHA-1197]: https://ably.atlassian.net/browse/CHA-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * sendMessage, updateMessage, and deleteMessage now return the complete server-generated message (including action, clientId, text, metadata, headers, version, and timestamps).
  * Client ID is no longer required when sending; the server supplies it.

* **Tests**
  * Expanded unit and integration tests and fixtures to validate server-populated fields, version (timestamp and clientId), and timestamp behavior; added a test spec annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->