### PR TITLE
Fix some incorrect initializer documentation

### DIFF
--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -137,9 +137,7 @@ public struct SendMessageReactionParams: Sendable {
      */
     public var count: Int?
 
-    /// Memberwise initializer to create a `SendMessageReactionParams`.
-    ///
-    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
+    /// Creates an instance with the given property values.
     public init(name: String, type: MessageReactionType? = nil, count: Int? = nil) {
         self.name = name
         self.type = type
@@ -162,9 +160,7 @@ public struct DeleteMessageReactionParams: Sendable {
      */
     public var name: String?
 
-    /// Memberwise initializer to create a `DeleteMessageReactionParams`.
-    ///
-    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
+    /// Creates an instance with the given property values.
     public init(name: String? = nil, type: MessageReactionType? = nil) {
         self.name = name
         self.type = type

--- a/Sources/AblyChat/RoomReactions.swift
+++ b/Sources/AblyChat/RoomReactions.swift
@@ -101,9 +101,7 @@ public struct SendReactionParams: Sendable {
      */
     public var headers: ReactionHeaders?
 
-    /// Memberwise initializer to create a `SendReactionParams`.
-    ///
-    /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
+    /// Creates an instance with the given property values.
     public init(name: String, metadata: ReactionMetadata? = nil, headers: ReactionHeaders? = nil) {
         self.name = name
         self.metadata = metadata


### PR DESCRIPTION
My mistake in 613792c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit public initializers for configuring message reaction actions, making setup simpler and supporting optional type and count values.

* **Documentation**
  * Clarified and simplified initializer documentation for reaction parameters, replacing legacy memberwise notes with clear guidance.
  * Aligned room reaction initializer docs for consistency; no behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->