### PR TITLE
Fix `CaseThatImpliesFixedStatusCode` cases

### DIFF
--- a/Sources/AblyChat/Errors.swift
+++ b/Sources/AblyChat/Errors.swift
@@ -62,8 +62,6 @@ public enum ErrorCode: Int {
         case roomIsReleased
         case roomReleasedBeforeOperationCompleted
         case roomDiscontinuity
-        case unableDeleteReactionWithoutName
-        case cannotApplyEventForDifferentMessage
         case messageRejectedByBeforePublishRule
         case messageRejectedByModeration
 
@@ -81,10 +79,6 @@ public enum ErrorCode: Int {
                 .roomReleasedBeforeOperationCompleted
             case .roomDiscontinuity:
                 .roomDiscontinuity
-            case .unableDeleteReactionWithoutName:
-                .badRequest
-            case .cannotApplyEventForDifferentMessage:
-                .badRequest
             case .messageRejectedByModeration:
                 .messageRejectedByModeration
             case .messageRejectedByBeforePublishRule:
@@ -100,9 +94,7 @@ public enum ErrorCode: Int {
                  .roomInFailedState,
                  .roomIsReleasing,
                  .roomIsReleased,
-                 .roomReleasedBeforeOperationCompleted,
-                 .unableDeleteReactionWithoutName,
-                 .cannotApplyEventForDifferentMessage:
+                 .roomReleasedBeforeOperationCompleted:
                 400
             case .messageRejectedByModeration,
                  .messageRejectedByBeforePublishRule:
@@ -200,9 +192,9 @@ internal enum ChatError {
         case .roomDiscontinuity:
             .fixedStatusCode(.roomDiscontinuity)
         case .unableDeleteReactionWithoutName:
-            .fixedStatusCode(.unableDeleteReactionWithoutName)
+            .fixedStatusCode(.badRequest)
         case .cannotApplyEventForDifferentMessage:
-            .fixedStatusCode(.cannotApplyEventForDifferentMessage)
+            .fixedStatusCode(.badRequest)
         case .messageRejectedByBeforePublishRule:
             .fixedStatusCode(.messageRejectedByBeforePublishRule)
         case .messageRejectedByModeration:


### PR DESCRIPTION
Remove two that don't correspond to `ErrorCode` cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized certain chat error responses to return a consistent Bad Request status instead of specialized codes, improving predictability across clients and logs.
  - Adjusted status code handling for specific edge cases during message operations; user-facing error messages remain unchanged.
  - This change may affect integrations that relied on the previous distinct status codes; ensure any error handling expecting those specific codes is updated to interpret Bad Request appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->