### PR TITLE
Flatten MessageReactionSummaryEvent structure

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -299,7 +299,7 @@ struct ContentView: View {
         room.messages.reactions.subscribe { summaryEvent in
             do {
                 try withAnimation {
-                    if let reactedMessageItem = listItemWithMessageSerial(summaryEvent.summary.messageSerial) {
+                    if let reactedMessageItem = listItemWithMessageSerial(summaryEvent.messageSerial) {
                         if let index = listItems.firstIndex(where: { $0.id == reactedMessageItem.message.serial }) {
                             listItems[index] = try .message(
                                 .init(

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -224,7 +224,6 @@ class MockMessageReactions: MessageReactions {
 
     private func getUniqueReactionsSummaryForMessage(_ messageSerial: String) -> MessageReactionSummary {
         MessageReactionSummary(
-            messageSerial: messageSerial,
             unique: [:],
             distinct: reactions.filter { $0.messageSerial == messageSerial }.reduce(into: [String: MessageReactionSummary.ClientIDList]()) { dict, newItem in
                 if var oldItem = dict[newItem.name] {
@@ -260,7 +259,8 @@ class MockMessageReactions: MessageReactions {
         mockSubscriptions.emit(
             MessageReactionSummaryEvent(
                 type: MessageReactionEvent.summary,
-                summary: getUniqueReactionsSummaryForMessage(messageSerial),
+                messageSerial: messageSerial,
+                reactions: getUniqueReactionsSummaryForMessage(messageSerial),
             ),
         )
     }
@@ -272,7 +272,8 @@ class MockMessageReactions: MessageReactions {
         mockSubscriptions.emit(
             MessageReactionSummaryEvent(
                 type: MessageReactionEvent.summary,
-                summary: getUniqueReactionsSummaryForMessage(messageSerial),
+                messageSerial: messageSerial,
+                reactions: getUniqueReactionsSummaryForMessage(messageSerial),
             ),
         )
     }
@@ -295,7 +296,8 @@ class MockMessageReactions: MessageReactions {
                 )
                 return MessageReactionSummaryEvent(
                     type: MessageReactionEvent.summary,
-                    summary: self.getUniqueReactionsSummaryForMessage(messageSerial),
+                    messageSerial: messageSerial,
+                    reactions: self.getUniqueReactionsSummaryForMessage(messageSerial),
                 )
             },
             interval: Double([Int](1 ... 10).randomElement()!) / 10.0,

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -83,8 +83,8 @@ internal final class DefaultMessageReactions: MessageReactions {
 
             let summaryEvent = MessageReactionSummaryEvent(
                 type: MessageReactionEvent.summary,
-                summary: MessageReactionSummary(
-                    messageSerial: messageSerial,
+                messageSerial: messageSerial,
+                reactions: MessageReactionSummary(
                     values: summaryJson ?? [:], // CHA-MR6a1
                 ),
             )

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -172,7 +172,6 @@ extension Message: JSONObjectDecodable {
         var reactionSummary: MessageReactionSummary?
         if let summaryJson = try? jsonObject.objectValueForKey("reactions"), !summaryJson.isEmpty {
             reactionSummary = MessageReactionSummary(
-                messageSerial: serial,
                 values: summaryJson,
             )
         }
@@ -225,12 +224,12 @@ public extension Message {
      */
     func with(_ summaryEvent: MessageReactionSummaryEvent) throws(ARTErrorInfo) -> Self {
         // (CHA-M11e) For MessageReactionSummaryEvent, the method must verify that the summary.messageSerial in the event matches the message’s own serial. If they don’t match, an error with code 40000 and status code 400 must be thrown.
-        guard serial == summaryEvent.summary.messageSerial else {
+        guard serial == summaryEvent.messageSerial else {
             throw ARTErrorInfo(chatError: .cannotApplyEventForDifferentMessage)
         }
 
         var newMessage = self
-        newMessage.reactions = summaryEvent.summary
+        newMessage.reactions = summaryEvent.reactions
         return newMessage
     }
 }

--- a/Sources/AblyChat/MessageReaction+JSON.swift
+++ b/Sources/AblyChat/MessageReaction+JSON.swift
@@ -2,15 +2,12 @@ import Foundation
 
 internal extension MessageReactionSummary {
     enum JSONKey: String {
-        case messageSerial
         case unique
         case distinct
         case multiple
     }
 
-    init(messageSerial: String, values jsonObject: [String: JSONValue]) {
-        self.messageSerial = messageSerial
-
+    init(values jsonObject: [String: JSONValue]) {
         // Two different key are used for now until fixed. Internal discussion:
         // https://ably-real-time.slack.com/archives/C02NY1VT3LY/p1749924228762039?thread_ts=1749655305.091679&cid=C02NY1VT3LY
         let uniqueJson = try? jsonObject.optionalObjectValueForKey(MessageReactionType.unique.rawValue) ??

--- a/Sources/AblyChat/MessageReaction.swift
+++ b/Sources/AblyChat/MessageReaction.swift
@@ -229,11 +229,6 @@ public struct MessageReactionSummary: Sendable, Equatable {
     }
 
     /**
-     * Reference to the original message's serial.
-     */
-    public var messageSerial: String
-
-    /**
      * Map of unique-type reactions summaries.
      */
     public var unique: [String: ClientIDList]
@@ -251,8 +246,7 @@ public struct MessageReactionSummary: Sendable, Equatable {
     /// Memberwise initializer to create a `MessageReactionSummary`.
     ///
     /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
-    public init(messageSerial: String, unique: [String: MessageReactionSummary.ClientIDList], distinct: [String: MessageReactionSummary.ClientIDList], multiple: [String: MessageReactionSummary.ClientIDCounts]) {
-        self.messageSerial = messageSerial
+    public init(unique: [String: MessageReactionSummary.ClientIDList], distinct: [String: MessageReactionSummary.ClientIDList], multiple: [String: MessageReactionSummary.ClientIDCounts]) {
         self.unique = unique
         self.distinct = distinct
         self.multiple = multiple
@@ -270,16 +264,22 @@ public struct MessageReactionSummaryEvent: Sendable, Equatable {
     public var type: MessageReactionEvent
 
     /**
+     * The serial of the message for which this reaction summary was created.
+     */
+    public var messageSerial: String
+
+    /**
      * The message reactions summary.
      */
-    public var summary: MessageReactionSummary
+    public var reactions: MessageReactionSummary
 
     /// Memberwise initializer to create a `MessageReactionSummaryEvent`.
     ///
     /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
-    public init(type: MessageReactionEvent, summary: MessageReactionSummary) {
+    public init(type: MessageReactionEvent, messageSerial: String, reactions: MessageReactionSummary) {
         self.type = type
-        self.summary = summary
+        self.messageSerial = messageSerial
+        self.reactions = reactions
     }
 }
 

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -146,21 +146,21 @@ struct DefaultMessageReactionsTests {
         defaultMessages.reactions.subscribe { event in
             // Then
             #expect(event.type == .summary)
-            #expect(type(of: event.summary.unique) == [String: MessageReactionSummary.ClientIDList].self)
-            #expect(event.summary.unique["like"]?.total == 2)
-            #expect(event.summary.unique["love"]?.total == 1)
-            #expect(event.summary.unique["like"]?.clientIDs.count == 2)
-            #expect(event.summary.unique["love"]?.clientIDs.count == 1)
-            #expect(type(of: event.summary.distinct) == [String: MessageReactionSummary.ClientIDList].self)
-            #expect(event.summary.distinct["like"]?.total == 2)
-            #expect(event.summary.distinct["love"]?.total == 1)
-            #expect(event.summary.distinct["like"]?.clientIDs.count == 2)
-            #expect(event.summary.distinct["love"]?.clientIDs.count == 1)
-            #expect(type(of: event.summary.multiple) == [String: MessageReactionSummary.ClientIDCounts].self)
-            #expect(event.summary.multiple["like"]?.total == 5)
-            #expect(event.summary.multiple["love"]?.total == 10)
-            #expect(event.summary.multiple["like"]?.clientIDs.count == 2)
-            #expect(event.summary.multiple["love"]?.clientIDs.count == 1)
+            #expect(type(of: event.reactions.unique) == [String: MessageReactionSummary.ClientIDList].self)
+            #expect(event.reactions.unique["like"]?.total == 2)
+            #expect(event.reactions.unique["love"]?.total == 1)
+            #expect(event.reactions.unique["like"]?.clientIDs.count == 2)
+            #expect(event.reactions.unique["love"]?.clientIDs.count == 1)
+            #expect(type(of: event.reactions.distinct) == [String: MessageReactionSummary.ClientIDList].self)
+            #expect(event.reactions.distinct["like"]?.total == 2)
+            #expect(event.reactions.distinct["love"]?.total == 1)
+            #expect(event.reactions.distinct["like"]?.clientIDs.count == 2)
+            #expect(event.reactions.distinct["love"]?.clientIDs.count == 1)
+            #expect(type(of: event.reactions.multiple) == [String: MessageReactionSummary.ClientIDCounts].self)
+            #expect(event.reactions.multiple["like"]?.total == 5)
+            #expect(event.reactions.multiple["love"]?.total == 10)
+            #expect(event.reactions.multiple["like"]?.clientIDs.count == 2)
+            #expect(event.reactions.multiple["love"]?.clientIDs.count == 1)
             callbackCalls += 1
         }
         #expect(callbackCalls == 1)
@@ -190,9 +190,9 @@ struct DefaultMessageReactionsTests {
         defaultMessages.reactions.subscribe { event in
             // Then
             #expect(event.type == .summary)
-            #expect(event.summary.unique.isEmpty)
-            #expect(event.summary.distinct.isEmpty)
-            #expect(event.summary.multiple.isEmpty)
+            #expect(event.reactions.unique.isEmpty)
+            #expect(event.reactions.distinct.isEmpty)
+            #expect(event.reactions.multiple.isEmpty)
             callbackCalls += 1
         }
         #expect(callbackCalls == 1)

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -156,35 +156,35 @@ struct IntegrationTests {
             }
         }
 
-        #expect(reactionSummaryEvents[0].summary.messageSerial == messageToReact.serial)
-        #expect(reactionSummaryEvents[0].summary.unique.isEmpty)
-        #expect(reactionSummaryEvents[0].summary.multiple.isEmpty)
-        #expect(reactionSummaryEvents[0].summary.distinct.count == 1)
-        _ = reactionSummaryEvents[0].summary.distinct.map { key, value in
+        #expect(reactionSummaryEvents[0].messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[0].reactions.unique.isEmpty)
+        #expect(reactionSummaryEvents[0].reactions.multiple.isEmpty)
+        #expect(reactionSummaryEvents[0].reactions.distinct.count == 1)
+        _ = reactionSummaryEvents[0].reactions.distinct.map { key, value in
             #expect(key == "👍")
             #expect(value.total == 1)
             #expect(value.clientIDs == [messageToReact.clientID])
         }
 
-        #expect(reactionSummaryEvents[1].summary.messageSerial == messageToReact.serial)
-        #expect(reactionSummaryEvents[1].summary.unique.isEmpty)
-        #expect(reactionSummaryEvents[1].summary.multiple.isEmpty)
-        #expect(reactionSummaryEvents[1].summary.distinct.count == 2)
+        #expect(reactionSummaryEvents[1].messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[1].reactions.unique.isEmpty)
+        #expect(reactionSummaryEvents[1].reactions.multiple.isEmpty)
+        #expect(reactionSummaryEvents[1].reactions.distinct.count == 2)
 
-        #expect(reactionSummaryEvents[2].summary.messageSerial == messageToReact.serial)
-        #expect(reactionSummaryEvents[2].summary.unique.isEmpty)
-        #expect(reactionSummaryEvents[2].summary.multiple.isEmpty)
-        #expect(reactionSummaryEvents[2].summary.distinct.count == 1)
-        _ = reactionSummaryEvents[2].summary.distinct.map { key, value in
+        #expect(reactionSummaryEvents[2].messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[2].reactions.unique.isEmpty)
+        #expect(reactionSummaryEvents[2].reactions.multiple.isEmpty)
+        #expect(reactionSummaryEvents[2].reactions.distinct.count == 1)
+        _ = reactionSummaryEvents[2].reactions.distinct.map { key, value in
             #expect(key == "🎉")
             #expect(value.total == 1)
             #expect(value.clientIDs == [messageToReact.clientID])
         }
 
-        #expect(reactionSummaryEvents[3].summary.messageSerial == messageToReact.serial)
-        #expect(reactionSummaryEvents[3].summary.unique.isEmpty)
-        #expect(reactionSummaryEvents[3].summary.multiple.isEmpty)
-        #expect(reactionSummaryEvents[3].summary.distinct.isEmpty)
+        #expect(reactionSummaryEvents[3].messageSerial == messageToReact.serial)
+        #expect(reactionSummaryEvents[3].reactions.unique.isEmpty)
+        #expect(reactionSummaryEvents[3].reactions.multiple.isEmpty)
+        #expect(reactionSummaryEvents[3].reactions.distinct.isEmpty)
 
         // MARK: - Message Reactions (Raw)
 
@@ -255,7 +255,6 @@ struct IntegrationTests {
         #expect(rxMessageFromHistory.serial == txMessageBeforeRxSubscribe.serial) // rxMessageFromHistory contains reactions and txMessageBeforeRxSubscribe doesn't, so we only compare serials
 
         let rxMessageFromHistoryReactions = try #require(rxMessageFromHistory.reactions)
-        #expect(rxMessageFromHistoryReactions.messageSerial == messageToReact.serial)
         #expect(rxMessageFromHistoryReactions.unique.isEmpty)
         #expect(rxMessageFromHistoryReactions.multiple.isEmpty)
         #expect(rxMessageFromHistoryReactions.distinct.count == 1)


### PR DESCRIPTION
Move messageSerial from nested MessageReactionSummary to top-level property on MessageReactionSummaryEvent and rename summary property to reactions for improved API ergonomics.

- Move messageSerial to MessageReactionSummaryEvent top-level
- Rename MessageReactionSummaryEvent.summary to .reactions
- Remove messageSerial from MessageReactionSummary type
- Update all event emission, handling, and test code

This is analogous to the changes in https://github.com/ably/ably-chat-js/pull/670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced message reaction visuals with rotation effects for more dynamic animations.
  - More reliable, real-time updates to reaction summaries in message lists.

- Refactor
  - Standardized reaction event structure across the app and example data for consistency.
  - Streamlined reaction data parsing to reduce payload size and surface key fields directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->