### PR TITLE
CI/local builds: use default Xcode 26 simulators

### DIFF
--- a/Sources/BuildTool/Platform.swift
+++ b/Sources/BuildTool/Platform.swift
@@ -11,9 +11,9 @@ enum Platform: String, CaseIterable {
         case .macOS:
             .fixed(platform: "macOS")
         case .iOS:
-            .lookup(destinationPredicate: .init(runtime: "iOS-18-4", deviceType: "iPhone-16"))
+            .lookup(destinationPredicate: .init(runtime: "iOS-26-0", deviceType: "iPhone-17"))
         case .tvOS:
-            .lookup(destinationPredicate: .init(runtime: "tvOS-18-4", deviceType: "Apple-TV-4K-3rd-generation-4K"))
+            .lookup(destinationPredicate: .init(runtime: "tvOS-26-0", deviceType: "Apple-TV-4K-3rd-generation-4K"))
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default platform destinations to latest runtimes: iOS now targets iOS 26.0 with iPhone 17; tvOS now targets tvOS 26.0 with Apple TV 4K (3rd generation, 4K).
  * Ensures compatibility with the latest SDKs and simulators.
  * No changes to behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->