### PR TITLE
Put version information into a namespace and remove a TODO

### DIFF
--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -115,7 +115,10 @@ public class ChatClient: ChatClientProtocol {
         self.realtime = suppliedRealtime
         self.clientOptions = clientOptions ?? .init()
 
-        let realtime = suppliedRealtime.createWrapperSDKProxy(with: .init(agents: agents))
+        // CHA-IN1a
+        let realtime = suppliedRealtime.createWrapperSDKProxy(
+            with: .init(agents: ClientInformation.agents),
+        )
         let internalRealtime = internalRealtimeClientFactory.createInternalRealtimeClient(realtime)
 
         logger = DefaultInternalLogger(logHandler: self.clientOptions.logHandler, logLevel: self.clientOptions.logLevel)

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -1,9 +1,10 @@
 import Ably
 
-// TODO: Just copied chat-js implementation for now to send up agent info. https://github.com/ably-labs/ably-chat-swift/issues/76
+/// Information about the Chat SDK.
+internal enum ClientInformation {
+    /// The version number of this version of the Chat SDK.
+    internal static let version = "0.8.0"
 
-// Update this when you release a new version
-// Version information
-internal let version = "0.8.0"
-
-internal let agents = ["chat-swift": version]
+    /// The agents to pass to `createWrapperSDKProxy` per CHA-IN1b.
+    internal static let agents = ["chat-swift": Self.version]
+}

--- a/Tests/AblyChatTests/ChatClientTests.swift
+++ b/Tests/AblyChatTests/ChatClientTests.swift
@@ -86,7 +86,7 @@ struct ChatClientTests {
             internalRealtimeClientFactory: MockInternalRealtimeClientFactory(createInternalRealtimeClientReturnValue: internalRealtine),
         )
 
-        #expect(realtime.createWrapperSDKProxyOptionsArgument?.agents == ["chat-swift": AblyChat.version])
+        #expect(realtime.createWrapperSDKProxyOptionsArgument?.agents == ["chat-swift": ClientInformation.version])
     }
 
     // @spec CHA-IN1d


### PR DESCRIPTION
`ClientInformation` name taken from that of a similar type in core SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated version and agent metadata into a unified internal source and updated initialization to use it. No public API changes.
* **Chores**
  * Updated internal SDK version to 0.8.0.
* **Tests**
  * Adjusted tests to align with the new internal structure.
* **Documentation**
  * Added inline documentation for internal client metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->