### PR TITLE
Fix non-macOS Swift Package Index builds

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,11 @@
+# Configuration for Swift Package Index builds
+# Reference: https://swiftpackageindex.com/swiftpackageindex/spimanifest/~/documentation/spimanifest
+
+version: 1
+builder:
+  configs:
+    # For non-macOS platforms, only build the AblyChat scheme; building BuildTool will fail on non-macOS platforms, making it look like we're not compatible with those platforms.
+    - platform: ios
+      scheme: AblyChat
+    - platform: tvos
+      scheme: AblyChat


### PR DESCRIPTION
See #302; hopefully this will resolve that (need to check next time SPI builds us).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Swift Package Index build configuration covering iOS and tvOS builders.
  * Ensures only the compatible build target is used on non-macOS systems to avoid spurious build failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->