### PR TITLE
Remove room release crash if task is cancelled

### DIFF
--- a/Sources/AblyChat/RoomLifecycleManager.swift
+++ b/Sources/AblyChat/RoomLifecycleManager.swift
@@ -565,9 +565,10 @@ internal class DefaultRoomLifecycleManager: RoomLifecycleManager {
                 // CHA-RL3n4: Retry until detach succeeds, with a pause before each attempt
                 let waitDuration = 0.25
                 logger.log(message: "Failed to detach channel, error \(error). Will retry in \(waitDuration)s.", level: .info)
-                // TODO: Make this not trap in the case where the Task is cancelled (as part of the broader https://github.com/ably-labs/ably-chat-swift/issues/29 for handling task cancellation)
-                // swiftlint:disable:next force_try
-                try! await clock.sleep(timeInterval: waitDuration)
+                // We're using an unstructured task so that this wait completes regardless of cancellation of the task that performed the release operation. But TODO think about the right behaviour in the case where the task is cancelled (as part of the broader https://github.com/ably-labs/ably-chat-swift/issues/29 for handling task cancellation)
+                _ = await Task {
+                    try await clock.sleep(timeInterval: waitDuration)
+                }.result
 
                 // Loop repeats
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rare crashes when canceling room release operations.
  * Ensured room detachment retries continue reliably until successful.

* **Stability**
  * Improved resilience of room lifecycle operations by isolating retry waits from unintended cancellations.
  * More reliable behavior under intermittent or poor network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->