### PR TITLE
Update and delete now accept serial instead of the message object

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -412,8 +412,15 @@ struct ContentView: View {
             }
             return nil
         }).first {
-            let editedMessage = editingMessageItem.message.copy(text: newMessage)
-            _ = try await room().messages.update(newMessage: editedMessage, details: nil)
+            _ = try await room().messages.update(
+                forSerial: editingMessageItem.message.serial,
+                params: .init(
+                    text: newMessage,
+                    metadata: editingMessageItem.message.metadata,
+                    headers: editingMessageItem.message.headers,
+                ),
+                details: nil,
+            )
         }
 
         newMessage = ""
@@ -421,7 +428,7 @@ struct ContentView: View {
 
     func deleteMessage(_ message: Message) {
         Task {
-            _ = try await room().messages.delete(message: message, details: nil)
+            _ = try await room().messages.delete(forSerial: message.serial, details: nil)
         }
     }
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -184,15 +184,19 @@ class MockMessages: Messages {
         return message
     }
 
-    func update(newMessage: Message, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    func update(forSerial serial: String, params: UpdateMessageParams, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         let message = Message(
-            serial: newMessage.serial,
+            serial: serial,
             action: .messageUpdate,
             clientID: clientID,
-            text: newMessage.text,
-            metadata: newMessage.metadata,
-            headers: newMessage.headers,
-            version: .init(serial: "\(Date().timeIntervalSince1970)", timestamp: Date(), clientID: clientID),
+            text: params.text,
+            metadata: params.metadata ?? [:],
+            headers: params.headers ?? [:],
+            version: .init(
+                serial: "\(Date().timeIntervalSince1970)",
+                timestamp: Date(),
+                clientID: clientID,
+            ),
             timestamp: Date(),
             reactions: .init(unique: [:], distinct: [:], multiple: [:]),
         )
@@ -200,19 +204,15 @@ class MockMessages: Messages {
         return message
     }
 
-    func delete(message: Message, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    func delete(forSerial serial: String, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         let message = Message(
-            serial: message.serial,
+            serial: serial,
             action: .messageDelete,
             clientID: clientID,
-            text: message.text,
-            metadata: message.metadata,
-            headers: message.headers,
-            version: .init(
-                serial: "\(Date().timeIntervalSince1970)",
-                timestamp: Date(),
-                clientID: clientID,
-            ),
+            text: "",
+            metadata: [:],
+            headers: [:],
+            version: .init(serial: "\(Date().timeIntervalSince1970)", timestamp: Date(), clientID: clientID),
             timestamp: Date(),
             reactions: .init(unique: [:], distinct: [:], multiple: [:]),
         )

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -79,14 +79,21 @@ internal final class ChatAPI {
 
     // (CHA-M8) A client must be able to update a message in a room.
     // (CHA-M8a) A client may update a message via the Chat REST API by calling the update method.
-    internal func updateMessage(roomName: String, with modifiedMessage: Message, details: OperationDetails?) async throws(InternalError) -> Message {
-        let endpoint = messageUrl(roomName: roomName, serial: modifiedMessage.serial)
+    internal func updateMessage(roomName: String, serial: String, updateParams: UpdateMessageParams, details: OperationDetails?) async throws(InternalError) -> Message {
+        let endpoint = messageUrl(roomName: roomName, serial: serial)
         var body: [String: JSONValue] = [:]
-        let messageObject: [String: JSONValue] = [
-            "text": .string(modifiedMessage.text),
-            "metadata": .object(modifiedMessage.metadata),
-            "headers": .object(modifiedMessage.headers.mapValues(\.toJSONValue)),
+
+        var messageObject: [String: JSONValue] = [
+            "text": .string(updateParams.text),
         ]
+
+        if let metadata = updateParams.metadata {
+            messageObject["metadata"] = .object(metadata)
+        }
+
+        if let headers = updateParams.headers {
+            messageObject["headers"] = .object(headers.mapValues(\.toJSONValue))
+        }
 
         body["message"] = .object(messageObject)
 
@@ -107,8 +114,8 @@ internal final class ChatAPI {
 
     // (CHA-M9) A client must be able to delete a message in a room.
     // (CHA-M9a) A client may delete a message via the Chat REST API by calling the delete method.
-    internal func deleteMessage(roomName: String, message: Message, details: OperationDetails?) async throws(InternalError) -> Message {
-        let endpoint = messageUrl(roomName: roomName, serial: message.serial, suffix: "/delete")
+    internal func deleteMessage(roomName: String, serial: String, details: OperationDetails?) async throws(InternalError) -> Message {
+        let endpoint = messageUrl(roomName: roomName, serial: serial, suffix: "/delete")
         var body: [String: JSONValue] = [:]
 
         if let description = details?.description {

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -131,17 +131,17 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal func update(newMessage: Message, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    internal func update(forSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         do {
-            return try await chatAPI.updateMessage(roomName: roomName, with: newMessage, details: details)
+            return try await chatAPI.updateMessage(roomName: roomName, serial: serial, updateParams: params, details: details)
         } catch {
             throw error.toARTErrorInfo()
         }
     }
 
-    internal func delete(message: Message, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    internal func delete(forSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         do {
-            return try await chatAPI.deleteMessage(roomName: roomName, message: message, details: details)
+            return try await chatAPI.deleteMessage(roomName: roomName, serial: serial, details: details)
         } catch {
             throw error.toARTErrorInfo()
         }

--- a/Sources/AblyChat/Message.swift
+++ b/Sources/AblyChat/Message.swift
@@ -100,7 +100,7 @@ public struct Message: Sendable, Equatable {
     }
 
     /**
-      * Helper function to copy a message with its properties replaced per the parameters. This is useful when updating a message e.g. `room().messages.update(newMessage: message.copy(text: "The updated text")`.
+      * Helper function to copy a message with its properties replaced per the parameters.
       *
       * If an argument is omitted or `nil`, then the current value of that property will be preserved.
      */

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -50,34 +50,54 @@ public protocol Messages: AnyObject, Sendable {
     func send(withParams params: SendMessageParams) async throws(ARTErrorInfo) -> Message
 
     /**
-     * Updates a message in the chat room.
+     * Update a message in the chat room.
      *
-     * This method uses the Ably Chat API endpoint for updating messages.
+     * Note that this method may return before OR after the updated message is
+     * received from the realtime channel. This means you may see the update that
+     * was just sent in a callback to `subscribe` before this method returns.
+     *
+     * NOTE: The Message instance returned by this method is the state of the message as a result of the update operation.
+     * If you have a subscription to message events via `subscribe`, you should discard the message instance returned by
+     * this method and use the event payloads from the subscription instead.
+     *
+     * This method uses PUT-like semantics: if headers and metadata are omitted from the updateParams, then
+     * the existing headers and metadata are replaced with the empty objects.
      *
      * - Parameters:
-     *   - newMessage: A copy of the `Message` object with the intended edits applied. Use the provided `copy` method on the existing message.
+     *   - serial: The serial of the message to update.
+     *   - updateParams: The parameters for updating the message.
      *   - details: Optional details to record about the update action.
      *
-     * - Returns: The updated message, with the `action` of the message set as `.update`.
-     *
-     * - Note: It is possible to receive your own message via the messages subscription before this method returns.
+     * - Returns: The updated message.
      */
-    func update(newMessage: Message, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
+    func update(forSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
 
     /**
-     * Deletes a message in the chat room.
+     * Delete a message in the chat room.
      *
-     * This method uses the Ably Chat API endpoint for deleting messages.
+     * This method uses the Ably Chat API REST endpoint for deleting messages.
+     * It performs a `soft` delete, meaning the message is marked as deleted.
+     *
+     * Note that this method may return before OR after the message is deleted
+     * from the realtime channel. This means you may see the message that was just
+     * deleted in a callback to `subscribe` before this method returns.
+     *
+     * NOTE: The Message instance returned by this method is the state of the message as a result of the delete operation.
+     * If you have a subscription to message events via `subscribe`, you should discard the message instance returned by
+     * this method and use the event payloads from the subscription instead.
+     *
+     * Should you wish to restore a deleted message, and providing you have the appropriate permissions,
+     * you can simply send an update to the original message.
+     * Note: This is subject to change in future versions, whereby a new permissions model will be introduced
+     * and a deleted message may not be restorable in this way.
      *
      * - Parameters:
-     *   - message: The message you wish to delete.
+     *   - serial: The serial of the message to delete.
      *   - details: Optional details to record about the delete action.
      *
-     * - Returns: The deleted message, with the action of the message set as `.delete`.
-     *
-     * - Note: It is possible to receive your own message via the messages subscription before this method returns.
+     * - Returns: The deleted message.
      */
-    func delete(message: Message, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
+    func delete(forSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
 
     /**
      * Get a message by its serial.

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -95,9 +95,11 @@ struct DefaultMessagesTests {
         let sentMessage = try Message(jsonObject: ["serial": "123456789-000@123456789:000", "version": ["serial": "123456789-000@123456789:000"], "text": .string(text), "clientId": "0", "action": "message.create", "metadata": [:], "headers": [:]]) // arbitrary
 
         // When
-        var newMessage = sentMessage
-        newMessage.text = text + "!" // see https://github.com/ably/ably-chat-swift/issues/333
-        let updatedMessage = try await defaultMessages.update(newMessage: newMessage, details: .init(description: "add exclamation", metadata: ["key": "val"]))
+        let updatedMessage = try await defaultMessages.update(
+            forSerial: sentMessage.serial,
+            params: .init(text: text + "!", metadata: [:], headers: [:]),
+            details: .init(description: "add exclamation", metadata: ["key": "val"]),
+        )
 
         // Then
         #expect(updatedMessage.serial == "123456789-000@123456789:000")
@@ -152,7 +154,7 @@ struct DefaultMessagesTests {
         let sentMessage = try Message(jsonObject: ["serial": "123456789-000@123456789:000", "version": ["serial": "123456789-000@123456789:000"], "text": .string(text), "clientId": "0", "action": "message.create", "metadata": ["key": "val"], "headers": [:]]) // arbitrary
 
         // When
-        let deletedMessage = try await defaultMessages.delete(message: sentMessage, details: nil)
+        let deletedMessage = try await defaultMessages.delete(forSerial: sentMessage.serial, details: nil)
 
         // Then
         #expect(deletedMessage.serial == "123456789-000@123456789:000")
@@ -207,8 +209,11 @@ struct DefaultMessagesTests {
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            let message = try Message(jsonObject: ["serial": "0", "version": ["serial": "0"], "text": "hey", "clientId": "0", "action": "message.update", "metadata": [:], "headers": [:]]) // arbitrary
-            _ = try await defaultMessages.update(newMessage: message, details: .init(description: "", metadata: [:]))
+            _ = try await defaultMessages.update(
+                forSerial: "0",
+                params: .init(text: "hey", metadata: [:], headers: [:]),
+                details: .init(description: "", metadata: [:]),
+            )
         }
         await #expect {
             try await doIt()
@@ -231,8 +236,7 @@ struct DefaultMessagesTests {
         // Then
         // TODO: avoids compiler crash (https://github.com/ably/ably-chat-swift/issues/233), revert once Xcode 16.3 released
         let doIt = {
-            let message = try Message(jsonObject: ["serial": "0", "version": ["serial": "0"], "text": "hey", "clientId": "0", "action": "message.update", "metadata": [:], "headers": [:]]) // arbitrary
-            _ = try await defaultMessages.delete(message: message, details: nil)
+            _ = try await defaultMessages.delete(forSerial: "0", details: nil)
         }
         await #expect {
             try await doIt()

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -288,7 +288,8 @@ struct IntegrationTests {
 
         // (1) Edit the message on the other client
         let txEditedMessage = try await txRoom.messages.update(
-            newMessage: messageToEditDelete.copy(
+            forSerial: messageToEditDelete.serial,
+            params: .init(
                 text: "edited message",
                 metadata: ["someEditedKey": 123, "someOtherEditedKey": "foo"],
                 headers: nil,
@@ -313,7 +314,7 @@ struct IntegrationTests {
 
         // (3) Delete the message on the other client
         let txDeleteMessage = try await txRoom.messages.delete(
-            message: rxEditedMessageFromSubscription,
+            forSerial: rxEditedMessageFromSubscription.serial,
             details: .init(
                 description: "deleted in testing",
                 metadata: ["foo": "bar"],


### PR DESCRIPTION
Closes #405 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Edit and delete messages by serial identifier using structured update parameters (text, metadata, headers).

- **Documentation**
  - Clarified REST-like vs realtime behavior, PUT-like semantics for updates, soft-delete behavior, and restoration guidance.

- **Refactor**
  - Public message APIs now accept a serial plus dedicated update parameter objects instead of requiring full message objects.

- **Tests**
  - Unit and integration tests updated to exercise the new serial-based edit/delete APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->