### PR TITLE
Messages.get implementation

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -219,6 +219,23 @@ class MockMessages: Messages {
         mockSubscriptions.emit(ChatMessageEvent(message: message))
         return message
     }
+
+    func get(withSerial serial: String) async throws(ARTErrorInfo) -> Message {
+        Message(
+            serial: serial,
+            action: .messageCreate,
+            clientID: clientID,
+            text: MockStrings.randomPhrase(),
+            metadata: [:],
+            headers: [:],
+            version: .init(
+                serial: serial,
+                timestamp: Date(),
+            ),
+            timestamp: Date(),
+            reactions: .init(unique: [:], distinct: [:], multiple: [:]),
+        )
+    }
 }
 
 class MockMessageReactions: MessageReactions {

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -33,6 +33,12 @@ internal final class ChatAPI {
         return try await makePaginatedRequest(endpoint, params: params.asQueryItems())
     }
 
+    // (CHA-M13) Get a single message by its serial
+    internal func getMessage(roomName: String, serial: String) async throws(InternalError) -> Message {
+        let endpoint = messageUrl(roomName: roomName, serial: serial)
+        return try await makeRequest(endpoint, method: "GET")
+    }
+
     internal struct SendMessageReactionParams: Sendable {
         internal let type: MessageReactionType
         internal let name: String

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -147,6 +147,15 @@ internal final class DefaultMessages: Messages {
         }
     }
 
+    // (CHA-M13) A single message must be retrievable from the REST API.
+    internal func get(withSerial serial: String) async throws(ARTErrorInfo) -> Message {
+        do {
+            return try await chatAPI.getMessage(roomName: roomName, serial: serial)
+        } catch {
+            throw error.toARTErrorInfo()
+        }
+    }
+
     private func resolveSubscriptionStart() async throws(InternalError) -> String {
         logger.log(message: "Resolving subscription start serial", level: .debug)
         // (CHA-M5a) If a subscription is added when the underlying realtime channel is ATTACHED, then the subscription point is the current channelSerial of the realtime channel.

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -80,6 +80,16 @@ public protocol Messages: AnyObject, Sendable {
     func delete(message: Message, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
 
     /**
+     * Get a message by its serial.
+     *
+     * - Parameters:
+     *   - serial: The serial of the message to get.
+     *
+     * - Returns: The message with the specified serial.
+     */
+    func get(withSerial serial: String) async throws(ARTErrorInfo) -> Message
+
+    /**
      * Add, delete, and subscribe to message reactions.
      */
     var reactions: Reactions { get }

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -143,24 +143,24 @@ struct ChatAPITests {
             paginatedResponse: paginatedResponse,
             items: [
                 Message(
-                    serial: "3446456",
+                    serial: "123456789-000@123456789:000",
                     action: .messageCreate,
                     clientID: "random",
                     text: "hello",
                     metadata: [:],
                     headers: [:],
-                    version: .init(serial: "3446456", timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)), // from successGetMessagesWithItems
+                    version: .init(serial: "123456789-000@123456789:000", timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)), // from successGetMessagesWithItems
                     timestamp: Date(timeIntervalSince1970: 1_730_943_049.269),
                     reactions: .empty,
                 ),
                 Message(
-                    serial: "3446457",
+                    serial: "123456789-000@123456789:001",
                     action: .messageCreate,
                     clientID: "random",
                     text: "hello response",
                     metadata: [:],
                     headers: [:],
-                    version: .init(serial: "3446457", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)),
+                    version: .init(serial: "123456789-000@123456789:001", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)),
                     timestamp: Date(timeIntervalSince1970: 1_730_943_051.269),
                     reactions: .empty,
                 ),

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -262,6 +262,14 @@ struct IntegrationTests {
             #expect(value.clientIDs == [messageToReact.clientID])
         }
 
+        // (8) Get a single message by its serial
+        let retrievedMessage = try await rxRoom.messages.get(withSerial: rxMessageFromHistory.serial)
+        #expect(retrievedMessage.serial == rxMessageFromHistory.serial)
+        #expect(retrievedMessage.text == rxMessageFromHistory.text)
+        #expect(retrievedMessage.clientID == rxMessageFromHistory.clientID)
+        // Verify the retrieved message has the same reaction summary
+        #expect(retrievedMessage.reactions.distinct.count == rxMessageFromHistory.reactions.distinct.count)
+
         // MARK: - Editing and Deleting Messages
 
         // Reuse message subscription and message from (5) and (6) above

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -101,25 +101,25 @@ extension MockHTTPPaginatedResponse {
         items: [
             [
                 "clientId": "random",
-                "serial": "3446456",
+                "serial": "123456789-000@123456789:000",
                 "action": "message.create",
                 "text": "hello",
                 "metadata": [:],
                 "headers": [:],
                 "version": [
-                    "serial": "3446456",
+                    "serial": "123456789-000@123456789:000",
                 ],
                 "timestamp": 1_730_943_049_269,
             ],
             [
                 "clientId": "random",
-                "serial": "3446457",
+                "serial": "123456789-000@123456789:001",
                 "action": "message.create",
                 "text": "hello response",
                 "metadata": [:],
                 "headers": [:],
                 "version": [
-                    "serial": "3446457",
+                    "serial": "123456789-000@123456789:001",
                 ],
                 "timestamp": 1_730_943_051_269,
             ],


### PR DESCRIPTION
Closes #416 

On top of #367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Retrieve a single message by its serial within a room via the Messages API.

- **Tests**
  - Added unit tests for single-message retrieval and error propagation.
  - Added integration test validating retrieved message content and reactions.
  - Updated test fixtures to use a new global serial format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->