### PR TITLE
Add `connectionID` to `PresenceMember`

### DIFF
--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -449,6 +449,7 @@ class MockPresence: Presence {
             randomElement: {
                 let member = PresenceMember(
                     clientID: MockStrings.names.randomElement()!,
+                    connectionID: "someConnectionID",
                     data: nil,
                     extras: nil,
                     updatedAt: Date(),
@@ -467,6 +468,7 @@ class MockPresence: Presence {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,
+                connectionID: "someConnectionID",
                 data: nil,
                 extras: nil,
                 updatedAt: Date(),
@@ -478,6 +480,7 @@ class MockPresence: Presence {
         MockStrings.names.shuffled().map { name in
             PresenceMember(
                 clientID: name,
+                connectionID: "someConnectionID",
                 data: nil,
                 extras: nil,
                 updatedAt: Date(),
@@ -500,6 +503,7 @@ class MockPresence: Presence {
     private func enter(dataForEvent: PresenceData?) async throws(ARTErrorInfo) {
         let member = PresenceMember(
             clientID: clientID,
+            connectionID: "someConnectionID",
             data: dataForEvent,
             extras: nil,
             updatedAt: Date(),
@@ -523,6 +527,7 @@ class MockPresence: Presence {
     private func update(dataForEvent: PresenceData? = nil) async throws(ARTErrorInfo) {
         let member = PresenceMember(
             clientID: clientID,
+            connectionID: "someConnectionID",
             data: dataForEvent,
             extras: nil,
             updatedAt: Date(),
@@ -546,6 +551,7 @@ class MockPresence: Presence {
     func leave(dataForEvent: PresenceData? = nil) async throws(ARTErrorInfo) {
         let member = PresenceMember(
             clientID: clientID,
+            connectionID: "someConnectionID",
             data: dataForEvent,
             extras: nil,
             updatedAt: Date(),

--- a/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
+++ b/Sources/AblyChat/AblyCocoaExtensions/InternalAblyCocoaTypes.swift
@@ -447,6 +447,7 @@ internal final class InternalRealtimeChannelsAdapter<Underlying: ProxyRealtimeCh
 /// A version of `ARTPresenceMessage` that uses strongly-typed `data` and `extras` properties. Only contains the properties that the Chat SDK is currently using; add as needed.
 internal struct PresenceMessage {
     internal var clientId: String?
+    internal var connectionID: String
     internal var timestamp: Date?
     internal var action: ARTPresenceAction
     internal var data: JSONObject?
@@ -456,6 +457,7 @@ internal struct PresenceMessage {
 internal extension PresenceMessage {
     init(ablyCocoaPresenceMessage: ARTPresenceMessage) {
         clientId = ablyCocoaPresenceMessage.clientId
+        connectionID = ablyCocoaPresenceMessage.connectionId
         timestamp = ablyCocoaPresenceMessage.timestamp
         action = ablyCocoaPresenceMessage.action
         if let ablyCocoaData = ablyCocoaPresenceMessage.data {

--- a/Sources/AblyChat/DefaultPresence.swift
+++ b/Sources/AblyChat/DefaultPresence.swift
@@ -227,6 +227,7 @@ internal final class DefaultPresence: Presence {
         let presenceMembers = try members.map { member throws(InternalError) in
             let presenceMember = PresenceMember(
                 clientID: member.clientId ?? "", // CHA-M4k1
+                connectionID: member.connectionID,
                 data: member.data,
                 extras: member.extras,
                 updatedAt: member.timestamp ?? Date(timeIntervalSince1970: 0), // CHA-M4k5
@@ -241,6 +242,7 @@ internal final class DefaultPresence: Presence {
     private func processPresenceSubscribe(_ message: PresenceMessage, for event: PresenceEventType) -> PresenceEvent {
         let member = PresenceMember(
             clientID: message.clientId ?? "", // CHA-M4k1
+            connectionID: message.connectionID,
             data: message.data,
             extras: message.extras,
             updatedAt: message.timestamp ?? Date(timeIntervalSince1970: 0), // CHA-M4k5

--- a/Sources/AblyChat/Presence.swift
+++ b/Sources/AblyChat/Presence.swift
@@ -152,8 +152,9 @@ public struct PresenceMember: Sendable {
     /// Memberwise initializer to create a `PresenceMember`.
     ///
     /// - Note: You should not need to use this initializer when using the Chat SDK. It is exposed only to allow users to create mock versions of the SDK's protocols.
-    public init(clientID: String, data: PresenceData?, extras: [String: JSONValue]?, updatedAt: Date) {
+    public init(clientID: String, connectionID: String, data: PresenceData?, extras: [String: JSONValue]?, updatedAt: Date) {
         self.clientID = clientID
+        self.connectionID = connectionID
         self.data = data
         self.extras = extras
         self.updatedAt = updatedAt
@@ -163,6 +164,9 @@ public struct PresenceMember: Sendable {
      * The clientId of the presence member.
      */
     public var clientID: String
+
+    /// The connection ID of this presence member.
+    public var connectionID: String
 
     /**
      * The data associated with the presence member.


### PR DESCRIPTION
In line with JS, which reuses the ably-js's `PresenceMessage` type which contains this property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Presence now includes a connectionID on members and messages, available across presence events and queries.
* **Refactor**
  * Updated the public PresenceMember initializer to require a connectionID parameter, adding a new connectionID property.
* **Chores**
  * Updated mock presence data to include connectionID in create, get, subscribe, enter, update, and leave paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->