### PR TITLE
Pin spec commit for `spec-coverage` job until URL-encoding issue decided

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,7 +53,8 @@ jobs:
           xcode-version: 26.0
 
       - name: Spec coverage
-        run: swift run BuildTool spec-coverage
+        # TODO: Remove spec-commit-sha once https://github.com/ably/specification/pull/387 merged
+        run: swift run BuildTool spec-coverage --spec-commit-sha e45eb90
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow to pass an explicit commit reference to the spec coverage step and added a clarifying inline comment. No user-facing changes.

* **Tests**
  * Spec coverage reporting now uses a specific commit during workflow execution. Application features, performance, and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->