### PR TITLE
Add `MessageReactions.clientReactions` method

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -53,8 +53,8 @@ jobs:
           xcode-version: 26.0
 
       - name: Spec coverage
-        # TODO: Remove spec-commit-sha once https://github.com/ably/specification/pull/387 merged
-        run: swift run BuildTool spec-coverage --spec-commit-sha e45eb90
+        # TODO: Remove spec-commit-sha once https://github.com/ably/specification/pull/387 and https://github.com/ably/specification/pull/393 merged
+        run: swift run BuildTool spec-coverage --spec-commit-sha 9cf3d9c
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -333,6 +333,10 @@ class MockMessageReactions: MessageReactions {
     func subscribeRaw(_: @escaping @MainActor @Sendable (MessageReactionRawEvent) -> Void) -> MockSubscription {
         fatalError("Not implemented")
     }
+
+    func clientReactions(forMessageWithSerial _: String, clientID _: String?) async throws(ARTErrorInfo) -> MessageReactionSummary {
+        fatalError("Not implemented")
+    }
 }
 
 class MockRoomReactions: RoomReactions {

--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -164,6 +164,28 @@ internal final class ChatAPI {
         return try await makeRequest(endpoint, method: "DELETE", params: httpParams)
     }
 
+    // CHA-MR13
+    internal func getClientReactions(forMessageWithSerial messageSerial: String, roomName: String, clientID: String?) async throws(InternalError) -> MessageReactionSummary {
+        // CHA-MR13b
+        let endpoint = messageUrl(roomName: roomName, serial: messageSerial, suffix: "/client-reactions")
+
+        var params: [String: String]?
+        if let clientID {
+            params = ["forClientId": clientID]
+        }
+
+        let response: MessageReactionSummaryResponse = try await makeRequest(endpoint, method: "GET", params: params)
+        return response.reactions
+    }
+
+    internal struct MessageReactionSummaryResponse: JSONObjectDecodable {
+        internal let reactions: MessageReactionSummary
+
+        internal init(jsonObject: [String: JSONValue]) throws(InternalError) {
+            reactions = MessageReactionSummary(values: jsonObject)
+        }
+    }
+
     private func makeRequest<Response: JSONDecodable>(_ url: String, method: String, params: [String: String]? = nil, body: RequestBody? = nil) async throws(InternalError) -> Response {
         let ablyCocoaBody: Any? = if let body {
             switch body {

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -145,4 +145,21 @@ internal final class DefaultMessageReactions: MessageReactions {
             self?.channel.unsubscribe(eventListener)
         }
     }
+
+    // CHA-MR13
+    internal func clientReactions(forMessageWithSerial messageSerial: String, clientID: String?) async throws(ARTErrorInfo) -> MessageReactionSummary {
+        do {
+            logger.log(message: "Fetching client reactions for message serial: \(messageSerial), clientId: \(clientID ?? "current client")", level: .debug)
+
+            // CHA-MR13b
+            let summary = try await chatAPI.getClientReactions(forMessageWithSerial: messageSerial, roomName: roomName, clientID: clientID)
+
+            logger.log(message: "Fetched client reactions for message serial: \(messageSerial)", level: .info)
+
+            return summary
+        } catch {
+            // CHA-MR13c
+            throw error.toARTErrorInfo()
+        }
+    }
 }

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -66,6 +66,7 @@ struct IntegrationTests {
 
         // (1) Create a couple of chat clients — one for sending and one for receiving
         let txClient = Self.createSandboxChatClient(apiKey: apiKey, loggingLabel: "tx")
+        let txClientID = try #require(txClient.clientID)
         let rxClient = Self.createSandboxChatClient(apiKey: apiKey, loggingLabel: "rx")
 
         // (2) Fetch a room
@@ -142,6 +143,15 @@ struct IntegrationTests {
 
         try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
         try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
+
+        // Before deleting, fetch the reactions summary for txClientID and check its contents
+        let reactionsForClient = try await rxRoom.messages.reactions.clientReactions(
+            forMessageWithSerial: messageToReact.serial,
+            clientID: txClientID,
+        )
+        #expect(reactionsForClient.distinct["👍"]?.clipped == true)
+        #expect(reactionsForClient.distinct["👍"]?.clientIDs == [txClientID])
+
         try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
         try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
 


### PR DESCRIPTION
**Note: This PR is based on top of #423.**

See https://github.com/ably/specification/pull/393.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Retrieve client-specific reaction summaries for a message via the MessageReactions API (per-client counts and metadata).
* Tests
  * Unit tests for client-specific reaction aggregation, request parameters, and error handling.
  * Integration tests verifying per-client reaction summaries before reaction deletion.
* Chores
  * Updated CI workflow notes and spec-coverage commit reference (no runtime impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->