### PR TITLE
Further naming tweaks

### DIFF
--- a/Example/AblyChatExample/ContentView.swift
+++ b/Example/AblyChatExample/ContentView.swift
@@ -413,7 +413,7 @@ struct ContentView: View {
             return nil
         }).first {
             _ = try await room().messages.update(
-                forSerial: editingMessageItem.message.serial,
+                withSerial: editingMessageItem.message.serial,
                 params: .init(
                     text: newMessage,
                     metadata: editingMessageItem.message.metadata,
@@ -428,7 +428,7 @@ struct ContentView: View {
 
     func deleteMessage(_ message: Message) {
         Task {
-            _ = try await room().messages.delete(forSerial: message.serial, details: nil)
+            _ = try await room().messages.delete(withSerial: message.serial, details: nil)
         }
     }
 
@@ -446,7 +446,7 @@ struct ContentView: View {
 
     func deleteMessageReaction(_ reaction: String, messageSerial: String) {
         Task {
-            try await room().messages.reactions.delete(forMessageWithSerial: messageSerial, params: .init(name: reaction, type: .distinct))
+            try await room().messages.reactions.delete(fromMessageWithSerial: messageSerial, params: .init(name: reaction, type: .distinct))
         }
     }
 

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -184,7 +184,7 @@ class MockMessages: Messages {
         return message
     }
 
-    func update(forSerial serial: String, params: UpdateMessageParams, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    func update(withSerial serial: String, params: UpdateMessageParams, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         let message = Message(
             serial: serial,
             action: .messageUpdate,
@@ -204,7 +204,7 @@ class MockMessages: Messages {
         return message
     }
 
-    func delete(forSerial serial: String, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    func delete(withSerial serial: String, details _: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         let message = Message(
             serial: serial,
             action: .messageDelete,
@@ -291,7 +291,7 @@ class MockMessageReactions: MessageReactions {
         )
     }
 
-    func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
+    func delete(fromMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         reactions.removeAll { reaction in
             reaction.messageSerial == messageSerial && reaction.name == params.name && reaction.clientID == clientID
         }

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -38,7 +38,7 @@ internal final class DefaultMessageReactions: MessageReactions {
     }
 
     // (CHA-MR11) Users should be able to delete a reaction from a message via the `delete` method of the `MessagesReactions` object
-    internal func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
+    internal func delete(fromMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo) {
         let reactionType = params.type ?? options.defaultMessageReactionType
         if reactionType != .unique, params.name == nil {
             throw ARTErrorInfo(chatError: .unableDeleteReactionWithoutName(reactionType: reactionType.rawValue))

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -131,7 +131,7 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal func update(forSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    internal func update(withSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         do {
             return try await chatAPI.updateMessage(roomName: roomName, serial: serial, updateParams: params, details: details)
         } catch {
@@ -139,7 +139,7 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal func delete(forSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
+    internal func delete(withSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message {
         do {
             return try await chatAPI.deleteMessage(roomName: roomName, serial: serial, details: details)
         } catch {

--- a/Sources/AblyChat/MessageReactions.swift
+++ b/Sources/AblyChat/MessageReactions.swift
@@ -28,7 +28,7 @@ public protocol MessageReactions: AnyObject, Sendable {
      *   - messageSerial: A serial of the message to remove the reaction from.
      *   - params: The type of reaction annotation and the specific reaction to remove. The reaction to remove is required for all types except ``MessageReactionType/unique``.
      */
-    func delete(forMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo)
+    func delete(fromMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ARTErrorInfo)
 
     /**
      * Subscribe to message reaction summaries. Use this to keep message reaction counts up to date efficiently in the UI.

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -70,7 +70,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: The updated message.
      */
-    func update(forSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
+    func update(withSerial serial: String, params: UpdateMessageParams, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
 
     /**
      * Delete a message in the chat room.
@@ -97,7 +97,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: The deleted message.
      */
-    func delete(forSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
+    func delete(withSerial serial: String, details: OperationDetails?) async throws(ARTErrorInfo) -> Message
 
     /**
      * Get a message by its serial.

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -26,7 +26,7 @@ struct DefaultMessageReactionsTests {
         // When
         let message = try await defaultMessages.send(withParams: .init(text: "a joke"))
         try await defaultMessages.reactions.send(forMessageWithSerial: message.serial, params: .init(name: "😆", type: .multiple, count: 10))
-        try await defaultMessages.reactions.delete(forMessageWithSerial: message.serial, params: .init(name: "😆", type: .multiple))
+        try await defaultMessages.reactions.delete(fromMessageWithSerial: message.serial, params: .init(name: "😆", type: .multiple))
 
         // Then
         #expect(realtime.callRecorder.hasRecord(
@@ -91,7 +91,7 @@ struct DefaultMessageReactionsTests {
 
         let thrownError = await #expect(throws: ARTErrorInfo.self) {
             // When
-            try await defaultMessages.reactions.delete(forMessageWithSerial: "", params: .init(name: "😐", type: .distinct))
+            try await defaultMessages.reactions.delete(fromMessageWithSerial: "", params: .init(name: "😐", type: .distinct))
         }
 
         // Then

--- a/Tests/AblyChatTests/DefaultMessagesTests.swift
+++ b/Tests/AblyChatTests/DefaultMessagesTests.swift
@@ -96,7 +96,7 @@ struct DefaultMessagesTests {
 
         // When
         let updatedMessage = try await defaultMessages.update(
-            forSerial: sentMessage.serial,
+            withSerial: sentMessage.serial,
             params: .init(text: text + "!", metadata: [:], headers: [:]),
             details: .init(description: "add exclamation", metadata: ["key": "val"]),
         )
@@ -154,7 +154,7 @@ struct DefaultMessagesTests {
         let sentMessage = try Message(jsonObject: ["serial": "123456789-000@123456789:000", "version": ["serial": "123456789-000@123456789:000"], "text": .string(text), "clientId": "0", "action": "message.create", "metadata": ["key": "val"], "headers": [:]]) // arbitrary
 
         // When
-        let deletedMessage = try await defaultMessages.delete(forSerial: sentMessage.serial, details: nil)
+        let deletedMessage = try await defaultMessages.delete(withSerial: sentMessage.serial, details: nil)
 
         // Then
         #expect(deletedMessage.serial == "123456789-000@123456789:000")
@@ -204,7 +204,7 @@ struct DefaultMessagesTests {
         // Then
         let thrownError = await #expect(throws: ARTErrorInfo.self) {
             _ = try await defaultMessages.update(
-                forSerial: "0",
+                withSerial: "0",
                 params: .init(text: "hey", metadata: [:], headers: [:]),
                 details: .init(description: "", metadata: [:]),
             )
@@ -225,7 +225,7 @@ struct DefaultMessagesTests {
 
         // Then
         let thrownError = await #expect(throws: ARTErrorInfo.self) {
-            _ = try await defaultMessages.delete(forSerial: "0", details: nil)
+            _ = try await defaultMessages.delete(withSerial: "0", details: nil)
         }
         #expect(thrownError == ARTErrorInfo(domain: "SomeDomain", code: 123))
     }

--- a/Tests/AblyChatTests/IntegrationTests.swift
+++ b/Tests/AblyChatTests/IntegrationTests.swift
@@ -152,8 +152,8 @@ struct IntegrationTests {
         #expect(reactionsForClient.distinct["👍"]?.clipped == true)
         #expect(reactionsForClient.distinct["👍"]?.clientIDs == [txClientID])
 
-        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
-        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
+        try await txRoom.messages.reactions.delete(fromMessageWithSerial: messageToReact.serial, params: .init(name: "👍"))
+        try await txRoom.messages.reactions.delete(fromMessageWithSerial: messageToReact.serial, params: .init(name: "🎉"))
 
         var reactionSummaryEvents = [MessageReactionSummaryEvent]()
 
@@ -200,7 +200,7 @@ struct IntegrationTests {
 
         try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "🔥"))
         try await txRoom.messages.reactions.send(forMessageWithSerial: messageToReact.serial, params: .init(name: "😆"))
-        try await txRoom.messages.reactions.delete(forMessageWithSerial: messageToReact.serial, params: .init(name: "😆")) // not deleting 🔥 to check it later in history request
+        try await txRoom.messages.reactions.delete(fromMessageWithSerial: messageToReact.serial, params: .init(name: "😆")) // not deleting 🔥 to check it later in history request
 
         var reactionRawEvents = [MessageReactionRawEvent]()
 
@@ -288,7 +288,7 @@ struct IntegrationTests {
 
         // (1) Edit the message on the other client
         let txEditedMessage = try await txRoom.messages.update(
-            forSerial: messageToEditDelete.serial,
+            withSerial: messageToEditDelete.serial,
             params: .init(
                 text: "edited message",
                 metadata: ["someEditedKey": 123, "someOtherEditedKey": "foo"],
@@ -314,7 +314,7 @@ struct IntegrationTests {
 
         // (3) Delete the message on the other client
         let txDeleteMessage = try await txRoom.messages.delete(
-            forSerial: rxEditedMessageFromSubscription.serial,
+            withSerial: rxEditedMessageFromSubscription.serial,
             details: .init(
                 description: "deleted in testing",
                 metadata: ["foo": "bar"],


### PR DESCRIPTION
Change `forSerial` to `withSerial` in `Messages.delete` and `Messages.update`. (In 103a812 I suggested `forSerial` because I thought `withSerial` would look like the serial is being used as a parameter to change the nature of the operation instead of identifying the message, but now that I've seen "for serial" being used it just looks weird.)

And change `MessageReactions.delete(forMessageWithSerial:…)` to `delete(fromMessageWithSerial:…)`; i.e. "delete reaction from the message with this serial".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed argument labels in messaging APIs for consistency:
    - Messages: update(forSerial:) → update(withSerial:), delete(forSerial:) → delete(withSerial:)
    - Message Reactions: delete(forMessageWithSerial:) → delete(fromMessageWithSerial:)
  * No behavioral changes; existing functionality remains the same.
  * Action required: Update your call sites to the new labels to resolve compile-time errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->