### PR TITLE
Temporary removing macOS and tvOS targets

### DIFF
--- a/Example/AblyChatExample.xcodeproj/project.pbxproj
+++ b/Example/AblyChatExample.xcodeproj/project.pbxproj
@@ -301,10 +301,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ably.AblyChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 17.0;
 			};
 			name = Debug;
@@ -344,10 +344,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ably.AblyChatExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 17.0;
 			};
 			name = Release;


### PR DESCRIPTION
`flip()` method for easy and smooth adding messages at the bottom of a view breaks clicks on macos/tvOS. There is no quick way of implementing this without flipping views, so I'll just remove those targets for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform support configuration to target iPhone and iPad devices only, removing macOS and Apple TV platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->