### PR TITLE
Simplify the way we handle `HTTPPaginatedResult`

### DIFF
--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -1,14 +1,14 @@
 import Ably
 
 @MainActor
-internal final class DefaultMessageReactions: MessageReactions {
+internal final class DefaultMessageReactions<Realtime: InternalRealtimeClientProtocol>: MessageReactions {
     private let channel: any InternalRealtimeChannelProtocol
     private let roomName: String
     private let logger: any InternalLogger
-    private let chatAPI: ChatAPI
+    private let chatAPI: ChatAPI<Realtime>
     private let options: MessagesOptions
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions, logger: any InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI<Realtime>, roomName: String, options: MessagesOptions, logger: any InternalLogger) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName
@@ -23,7 +23,7 @@ internal final class DefaultMessageReactions: MessageReactions {
             count = 1
         }
 
-        let apiParams: ChatAPI.SendMessageReactionParams = .init(
+        let apiParams: ChatAPISendMessageReactionParams = .init(
             type: params.type ?? options.defaultMessageReactionType,
             name: params.name,
             count: count,
@@ -40,7 +40,7 @@ internal final class DefaultMessageReactions: MessageReactions {
             // CHA-MR11b1
             throw InternalError.unableDeleteReactionWithoutName(reactionType: reactionType.rawValue).toErrorInfo()
         }
-        let apiParams: ChatAPI.DeleteMessageReactionParams = .init(
+        let apiParams: ChatAPIDeleteMessageReactionParams = .init(
             type: reactionType,
             name: reactionType != .unique ? params.name : nil,
         )

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -1,12 +1,12 @@
 import Ably
 
-internal final class DefaultMessages: Messages {
-    internal let reactions: DefaultMessageReactions
+internal final class DefaultMessages<Realtime: InternalRealtimeClientProtocol>: Messages {
+    internal let reactions: DefaultMessageReactions<Realtime>
 
     private let channel: any InternalRealtimeChannelProtocol
 
     private let roomName: String
-    private let chatAPI: ChatAPI
+    private let chatAPI: ChatAPI<Realtime>
     private let logger: any InternalLogger
 
     private var currentSubscriptionPoint: String?
@@ -25,7 +25,7 @@ internal final class DefaultMessages: Messages {
         }
     }
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, options: MessagesOptions = .init(), logger: any InternalLogger) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI<Realtime>, roomName: String, options: MessagesOptions = .init(), logger: any InternalLogger) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -1,15 +1,15 @@
 import Ably
 
-internal final class DefaultOccupancy: Occupancy {
+internal final class DefaultOccupancy<Realtime: InternalRealtimeClientProtocol>: Occupancy {
     private let channel: any InternalRealtimeChannelProtocol
-    private let chatAPI: ChatAPI
+    private let chatAPI: ChatAPI<Realtime>
     private let roomName: String
     private let logger: any InternalLogger
     private let options: OccupancyOptions
 
     private var lastOccupancyData: OccupancyData?
 
-    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI, roomName: String, logger: any InternalLogger, options: OccupancyOptions) {
+    internal init(channel: any InternalRealtimeChannelProtocol, chatAPI: ChatAPI<Realtime>, roomName: String, logger: any InternalLogger, options: OccupancyOptions) {
         self.channel = channel
         self.chatAPI = chatAPI
         self.roomName = roomName

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -242,13 +242,13 @@ internal protocol RoomFactory: Sendable {
     associatedtype Realtime: InternalRealtimeClientProtocol where Realtime.Channels.Channel.Proxied == Room.Channel
     associatedtype Room: AblyChat.InternalRoom
 
-    func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> Room
+    func createRoom(realtime: Realtime, chatAPI: ChatAPI<Realtime>, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> Room
 }
 
 internal final class DefaultRoomFactory<Realtime: InternalRealtimeClientProtocol>: Sendable, RoomFactory {
     private let lifecycleManagerFactory = DefaultRoomLifecycleManagerFactory()
 
-    internal func createRoom(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> DefaultRoom<Realtime, DefaultRoomLifecycleManager> {
+    internal func createRoom(realtime: Realtime, chatAPI: ChatAPI<Realtime>, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> DefaultRoom<Realtime, DefaultRoomLifecycleManager> {
         try DefaultRoom(
             realtime: realtime,
             chatAPI: chatAPI,
@@ -263,12 +263,12 @@ internal final class DefaultRoomFactory<Realtime: InternalRealtimeClientProtocol
 internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleManager: RoomLifecycleManager>: InternalRoom {
     internal let name: String
     internal let options: RoomOptions
-    private let chatAPI: ChatAPI
+    private let chatAPI: ChatAPI<Realtime>
 
-    internal let messages: DefaultMessages
+    internal let messages: DefaultMessages<Realtime>
     internal let reactions: DefaultRoomReactions
     internal let presence: DefaultPresence
-    internal let occupancy: DefaultOccupancy
+    internal let occupancy: DefaultOccupancy<Realtime>
     internal let typing: DefaultTyping
 
     // Exposed for testing.
@@ -290,7 +290,7 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleMa
 
     private let logger: any InternalLogger
 
-    internal init<LifecycleManagerFactory: RoomLifecycleManagerFactory>(realtime: Realtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger, lifecycleManagerFactory: LifecycleManagerFactory) throws(ErrorInfo) where LifecycleManagerFactory.Manager == LifecycleManager {
+    internal init<LifecycleManagerFactory: RoomLifecycleManagerFactory>(realtime: Realtime, chatAPI: ChatAPI<Realtime>, name: String, options: RoomOptions, logger: any InternalLogger, lifecycleManagerFactory: LifecycleManagerFactory) throws(ErrorInfo) where LifecycleManagerFactory.Manager == LifecycleManager {
         self.realtime = realtime
         self.name = name
         self.options = options

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -65,7 +65,7 @@ public extension Rooms {
 
 internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     private let realtime: RoomFactory.Realtime
-    private let chatAPI: ChatAPI
+    private let chatAPI: ChatAPI<RoomFactory.Realtime>
 
     #if DEBUG
         internal var testsOnly_realtime: RoomFactory.Realtime {

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -81,8 +81,8 @@ internal struct DefaultStatusSubscription: StatusSubscription, Sendable {
     }
 }
 
-internal struct DefaultMessageSubscriptionResponse: MessageSubscriptionResponse, Sendable {
-    private let chatAPI: ChatAPI
+internal struct DefaultMessageSubscriptionResponse<Realtime: InternalRealtimeClientProtocol>: MessageSubscriptionResponse, Sendable {
+    private let chatAPI: ChatAPI<Realtime>
     private let roomName: String
     private let subscriptionStartSerial: @MainActor @Sendable () async throws(ErrorInfo) -> String
     private let _unsubscribe: () -> Void
@@ -104,7 +104,7 @@ internal struct DefaultMessageSubscriptionResponse: MessageSubscriptionResponse,
     }
 
     internal init(
-        chatAPI: ChatAPI,
+        chatAPI: ChatAPI<Realtime>,
         roomName: String,
         subscriptionStartSerial: @MainActor @escaping @Sendable () async throws(ErrorInfo) -> String,
         unsubscribe: @MainActor @Sendable @escaping () -> Void,

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -108,7 +108,7 @@ struct ChatAPITests {
 
     // @specOneOf(1/2) CHA-M6
     @Test
-    func getMessages_whenGetMessagesReturnsNoItems_returnsEmptyPaginatedResult() async {
+    func getMessages_whenGetMessagesReturnsNoItems_returnsEmptyPaginatedResult() async throws {
         // Given
         let paginatedResponse = MockHTTPPaginatedResponse.successGetMessagesWithNoItems
         let realtime = MockRealtime {
@@ -116,13 +116,13 @@ struct ChatAPITests {
         }
         let chatAPI = ChatAPI(realtime: realtime)
         let roomName = "basketball"
-        let expectedPaginatedResult = PaginatedResultWrapper<Message>(
-            paginatedResponse: paginatedResponse,
+        let expectedPaginatedResult = DefaultPaginatedResult<MockHTTPPaginatedResponse, Message>(
+            underlying: paginatedResponse,
             items: [],
         )
 
         // When
-        let getMessages = try? await chatAPI.getMessages(roomName: roomName, params: .init()) as? PaginatedResultWrapper<Message>
+        let getMessages = try await chatAPI.getMessages(roomName: roomName, params: .init())
 
         // Then
         #expect(getMessages == expectedPaginatedResult)
@@ -138,8 +138,8 @@ struct ChatAPITests {
         }
         let chatAPI = ChatAPI(realtime: realtime)
         let roomName = "basketball"
-        let expectedPaginatedResult = PaginatedResultWrapper<Message>(
-            paginatedResponse: paginatedResponse,
+        let expectedPaginatedResult = DefaultPaginatedResult<MockHTTPPaginatedResponse, Message>(
+            underlying: paginatedResponse,
             items: [
                 Message(
                     serial: "123456789-000@123456789:000",
@@ -167,10 +167,10 @@ struct ChatAPITests {
         )
 
         // When
-        let getMessagesResult = try #require(await chatAPI.getMessages(roomName: roomName, params: .init()) as? PaginatedResultWrapper<Message>)
+        let getMessagesResult = try await chatAPI.getMessages(roomName: roomName, params: .init())
 
         // Then
-        #expect(getMessagesResult.items == expectedPaginatedResult.items)
+        #expect(getMessagesResult == expectedPaginatedResult)
     }
 
     // @spec CHA-M5i
@@ -186,7 +186,7 @@ struct ChatAPITests {
 
         let thrownError = try await #require(throws: ErrorInfo.self) {
             // When
-            try await chatAPI.getMessages(roomName: roomName, params: .init()) as? PaginatedResultWrapper<Message>
+            _ = try await chatAPI.getMessages(roomName: roomName, params: .init())
         }
 
         // Then

--- a/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
+++ b/Tests/AblyChatTests/Mocks/MockHTTPPaginatedResponse.swift
@@ -1,54 +1,34 @@
 import Ably
+@testable import AblyChat
 
-final class MockHTTPPaginatedResponse: ARTHTTPPaginatedResponse, @unchecked Sendable {
-    private let _items: [NSDictionary]
-    private let _statusCode: Int
-    private let _headers: [String: String]
-    private let _hasNext: Bool
+final class MockHTTPPaginatedResponse: InternalHTTPPaginatedResponseProtocol {
+    let items: [JSONValue]
+    let statusCode: Int
+    let headers: [String: String]
+    let hasNext: Bool
 
     init(
-        items: [NSDictionary],
+        items: [[String: JSONValue]],
         statusCode: Int = 200,
         headers: [String: String] = [:],
         hasNext: Bool = false,
     ) {
-        _items = items
-        _statusCode = statusCode
-        _headers = headers
-        _hasNext = hasNext
-        super.init()
+        self.items = items.map { .object($0) }
+        self.statusCode = statusCode
+        self.headers = headers
+        self.hasNext = hasNext
     }
 
-    override var items: [NSDictionary] {
-        _items
+    var isLast: Bool {
+        !hasNext
     }
 
-    override var statusCode: Int {
-        _statusCode
+    func next() async throws(ErrorInfo) -> MockHTTPPaginatedResponse? {
+        hasNext ? MockHTTPPaginatedResponse.nextPage : nil
     }
 
-    override var headers: [String: String] {
-        _headers
-    }
-
-    override var success: Bool {
-        (statusCode >= 200) && (statusCode < 300)
-    }
-
-    override var hasNext: Bool {
-        _hasNext
-    }
-
-    override var isLast: Bool {
-        !_hasNext
-    }
-
-    override func next(_ callback: @escaping ARTHTTPPaginatedCallback) {
-        callback(hasNext ? MockHTTPPaginatedResponse.nextPage : nil, nil)
-    }
-
-    override func first(_ callback: @escaping ARTHTTPPaginatedCallback) {
-        callback(self, nil)
+    func first() async throws(ErrorInfo) -> MockHTTPPaginatedResponse {
+        self
     }
 }
 

--- a/Tests/AblyChatTests/Mocks/MockRealtime.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtime.swift
@@ -8,7 +8,7 @@ final class MockRealtime: InternalRealtimeClientProtocol {
 
     let connection: MockConnection
     let channels: MockChannels
-    let paginatedCallback: (@Sendable () throws(ErrorInfo) -> ARTHTTPPaginatedResponse)?
+    let paginatedCallback: (@MainActor () throws(ErrorInfo) -> MockHTTPPaginatedResponse)?
 
     private(set) var requestArguments: [(method: String, path: String, params: [String: String]?, body: Any?, headers: [String: String]?)] = []
 
@@ -19,14 +19,14 @@ final class MockRealtime: InternalRealtimeClientProtocol {
     init(
         channels: MockChannels = .init(channels: []),
         connection: MockConnection = .init(),
-        paginatedCallback: (@Sendable () throws(ErrorInfo) -> ARTHTTPPaginatedResponse)? = nil,
+        paginatedCallback: (@MainActor () throws(ErrorInfo) -> MockHTTPPaginatedResponse)? = nil,
     ) {
         self.channels = channels
         self.paginatedCallback = paginatedCallback
         self.connection = connection
     }
 
-    func request(_ method: String, path: String, params: [String: String]?, body: Any?, headers: [String: String]?) async throws(ErrorInfo) -> ARTHTTPPaginatedResponse {
+    func request(_ method: String, path: String, params: [String: String]?, body: Any?, headers: [String: String]?) async throws(ErrorInfo) -> MockHTTPPaginatedResponse {
         requestArguments.append((method: method, path: path, params: params, body: body, headers: headers))
         guard let paginatedCallback else {
             fatalError("Paginated callback not set")

--- a/Tests/AblyChatTests/Mocks/MockRoom.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoom.swift
@@ -16,7 +16,7 @@ class MockRoom: InternalRoom {
         fatalError("Not implemented")
     }
 
-    var messages: DefaultMessages {
+    var messages: DefaultMessages<MockRealtime> {
         fatalError("Not implemented")
     }
 
@@ -32,7 +32,7 @@ class MockRoom: InternalRoom {
         fatalError("Not implemented")
     }
 
-    var occupancy: DefaultOccupancy {
+    var occupancy: DefaultOccupancy<MockRealtime> {
         fatalError("Not implemented")
     }
 

--- a/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
+++ b/Tests/AblyChatTests/Mocks/MockRoomFactory.swift
@@ -3,7 +3,7 @@
 class MockRoomFactory: RoomFactory {
     private var room: MockRoom?
     private(set) var createRoomCallCount = 0
-    private(set) var createRoomArguments: (realtime: MockRealtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger)?
+    private(set) var createRoomArguments: (realtime: MockRealtime, chatAPI: ChatAPI<MockRealtime>, name: String, options: RoomOptions, logger: any InternalLogger)?
 
     init(room: MockRoom? = nil) {
         self.room = room
@@ -13,7 +13,7 @@ class MockRoomFactory: RoomFactory {
         self.room = room
     }
 
-    func createRoom(realtime: MockRealtime, chatAPI: ChatAPI, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> MockRoom {
+    func createRoom(realtime: MockRealtime, chatAPI: ChatAPI<MockRealtime>, name: String, options: RoomOptions, logger: any InternalLogger) throws(ErrorInfo) -> MockRoom {
         createRoomCallCount += 1
         createRoomArguments = (realtime: realtime, chatAPI: chatAPI, name: name, options: options, logger: logger)
 


### PR DESCRIPTION
Make it consistent with the rest of the codebase — an internal `MainActor`-isolated protocol and an adapter.

Side note: This was all done by Claude, with the exception of a single comment; thought it'd be a good task for which to try following people's advice of "try getting it to do a task without touching the code yourself at all"; there was a lot of back-and-forth but we got there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal architecture improvements to enhance type safety and generics throughout the SDK.
  * Improved pagination handling with enhanced error management and response processing.
  * Updated internal test infrastructure to align with new architecture patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->