### PR TITLE
Fix bug where typing timers not being reset

### DIFF
--- a/Sources/AblyChat/TypingTimerManager.swift
+++ b/Sources/AblyChat/TypingTimerManager.swift
@@ -41,6 +41,7 @@ internal final class TypingTimerManager<AnyClock: ClockProtocol>: TypingTimerMan
     // MARK: Managing CHA-T13b1 "is this person typing" timers
 
     /// Starts a CHA-T13b1 "is this person typing" timer, thus adding this clientID to the typing set.
+    /// If the clientID is already in the typing set, this will reset the timer (CHA-T13b2).
     internal func startTypingTimer(for clientID: String, handler: (@MainActor () -> Void)? = nil) {
         let timerManager = whoIsTypingTimers[clientID] ?? TimerManager(clock: clock)
         whoIsTypingTimers[clientID] = timerManager
@@ -97,6 +98,7 @@ internal protocol TypingTimerManagerProtocol {
     /// Clears any active CHA-T4a4 heartbeat timer.
     func cancelHeartbeatTimer()
     /// Starts a CHA-T13b1 "is this person typing" timer, thus adding this clientID to the typing set.
+    /// If the clientID is already in the typing set, this will reset the timer (CHA-T13b2).
     func startTypingTimer(for clientID: String, handler: (@MainActor () -> Void)?)
     /// Per CHA-T13b4, cancels the CHA-T13b1 "is this person typing" timer, thus removing this clientID from the typing set.
     func cancelTypingTimer(for clientID: String)

--- a/Tests/AblyChatTests/TypingTimerManagerTests.swift
+++ b/Tests/AblyChatTests/TypingTimerManagerTests.swift
@@ -8,7 +8,7 @@ import Testing
 final class TypingTimerManagerTests {
     @available(iOS 16.0, tvOS 16, *)
     func createTypingTimerManager(with testClock: MockTestClock) -> TypingTimerManager<MockTestClock> {
-        return TypingTimerManager(
+        TypingTimerManager(
             heartbeatThrottle: 1.0,
             gracePeriod: 0.5,
             logger: TestLogger(),
@@ -104,11 +104,9 @@ final class TypingTimerManagerTests {
         #expect(timerManager.currentlyTypingClientIDs().isEmpty)
     }
 
-    // @spec CHA-T13b2 - Tests that each additional typing heartbeat resets the timeout
-    // @spec CHA-T4b - Tests extending the timeout when typing is already in progress
     @Test
     @available(iOS 16.0, tvOS 16, *)
-    func timerReset() async {
+    func startTypingTimer_resetsTimerWhenClientAlreadyInTypingSet() async {
         let mockClock = MockTestClock()
         let timerManager = createTypingTimerManager(with: mockClock)
 


### PR DESCRIPTION
This fixes the implementation of CHA-T13b; we were ignoring "typing started" events for users already in the typing set instead of resetting their timer. The result of this is that a user who was typing continuously for a long time would appear after a while to have stopped typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typing inactivity timer now reliably resets when a user sends additional typing events, preventing premature timeouts.
  * Typing stop notifications are consistently emitted when the inactivity timer expires.
  * Started-typing notifications are only broadcast for clients that were not already marked as typing, improving multi-client indicator accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->