### PR TITLE
[ECO-5616] Align with spec on error when deleting message reaction without name

### DIFF
--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -37,7 +37,7 @@ internal final class DefaultMessageReactions<Realtime: InternalRealtimeClientPro
     internal func delete(fromMessageWithSerial messageSerial: String, params: DeleteMessageReactionParams) async throws(ErrorInfo) {
         let reactionType = params.type ?? options.defaultMessageReactionType
         if reactionType != .unique, params.name == nil {
-            // CHA-MR11b1
+            // CHA-MR11b1a
             throw InternalError.unableDeleteReactionWithoutName(reactionType: reactionType.rawValue).toErrorInfo()
         }
         let apiParams: ChatAPIDeleteMessageReactionParams = .init(

--- a/Sources/AblyChat/InternalError.swift
+++ b/Sources/AblyChat/InternalError.swift
@@ -73,14 +73,14 @@ internal enum InternalError {
     /// Error code is `roomDiscontinuity`.
     case roomDiscontinuity(cause: ErrorInfo?)
 
+    /// The user attempted to delete a reaction of type different than `unique`, without specifying the reaction identifier. This is not allowed per CHA-MR11b1a.
+    ///
+    /// Error code is `invalidArgument`.
+    case unableDeleteReactionWithoutName(reactionType: String)
+
     // MARK: - Errors not from the spec
 
     // TODO: Revisit the non-specified errors as part of https://github.com/ably/ably-chat-swift/issues/438
-
-    /// The user attempted to delete a reaction of type different than `unique`, without specifying the reaction identifier. This is not allowed per CHA-MR11b1.
-    ///
-    /// Error code is `badRequest` (this is not specified by the spec, which does not make it explicit that the SDK should throw an error in this scenario).
-    case unableDeleteReactionWithoutName(reactionType: String)
 
     /// Unable to fetch `historyBeforeSubscribe` because the `DefaultMessages` instance that stores the subscription points has been deallocated.
     ///
@@ -176,7 +176,7 @@ internal enum InternalError {
         case .roomDiscontinuity:
             .roomDiscontinuity
         case .unableDeleteReactionWithoutName:
-            .badRequest
+            .invalidArgument
         case .cannotApplyMessageEventForDifferentMessage:
             .invalidArgument
         case .cannotApplyReactionSummaryEventForDifferentMessage:

--- a/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
+++ b/Tests/AblyChatTests/DefaultMessageReactionsTests.swift
@@ -98,6 +98,26 @@ struct DefaultMessageReactionsTests {
         #expect(thrownError == InternalError.deleteMessageReactionEmptyMessageSerial.toErrorInfo())
     }
 
+    // @spec CHA-MR11b1a
+    @Test
+    func errorShouldBeThrownIfNameNotSuppliedWhenDeletingNonUniqueReaction() async throws {
+        // Given
+        let realtime = MockRealtime {
+            MockHTTPPaginatedResponse.successSendMessage
+        }
+        let chatAPI = ChatAPI(realtime: realtime)
+        let channel = MockRealtimeChannel(initialState: .attached)
+        let defaultMessages = DefaultMessages(channel: channel, chatAPI: chatAPI, roomName: "basketball", logger: TestLogger())
+
+        let thrownError = await #expect(throws: ErrorInfo.self) {
+            // When
+            try await defaultMessages.reactions.delete(fromMessageWithSerial: "arbitrary", params: .init(name: nil, type: .multiple))
+        }
+
+        // Then
+        #expect(thrownError == InternalError.unableDeleteReactionWithoutName(reactionType: "reaction:multiple.v1").toErrorInfo())
+    }
+
     // @spec CHA-MR3
     // @spec CHA-MR3b
     // @spec CHA-MR3b2


### PR DESCRIPTION
See https://github.com/ably/specification/pull/398.

Part of #438.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for deleting non-unique message reactions when the required reaction name is not provided; adjusted the reported error classification.

* **Tests**
  * Added test coverage validating that the appropriate error is raised when attempting to delete a non-unique reaction without supplying a name.

* **Chores**
  * Minor internal comment clarification with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->