### PR TITLE
[ECO-5596] Presence subscribe tests

### DIFF
--- a/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
+++ b/Tests/AblyChatTests/Mocks/MockRealtimeChannel.swift
@@ -2,7 +2,7 @@ import Ably
 @testable import AblyChat
 
 final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
-    let presence = MockRealtimePresence()
+    let presence: MockRealtimePresence
     let annotations: MockRealtimeAnnotations
     let proxied = MockAblyCocoaRealtime.Channel()
 
@@ -44,6 +44,7 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
         attachSerial = properties.attachSerial
         channelSerial = properties.channelSerial
         self.stateChangeToEmitForListener = stateChangeToEmitForListener
+        presence = MockRealtimePresence()
         annotations = MockRealtimeAnnotations(annotationToEmitOnSubscribe: annotationToEmitOnSubscribe)
     }
 
@@ -207,5 +208,9 @@ final class MockRealtimeChannel: InternalRealtimeChannelProtocol {
 
     func publish(_ name: String?, data: JSONValue?, extras: [String: JSONValue]?) {
         publishedMessages.append(TestMessage(name: name, data: data, extras: extras))
+    }
+
+    func emitPresenceMessage(_ message: ARTPresenceMessage) {
+        presence.emitMessage(message)
     }
 }


### PR DESCRIPTION
Closes #396 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test validating subscription to presence events and correct event sequencing (enter, update, leave) including unsubscribe behavior.
  * Improved mock presence/channel behavior to support real subscription, emission and teardown of presence events for more reliable test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->