### PR TITLE
[ECO-5397] Bump ably-cocoa to 1.2.51

### DIFF
--- a/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AblyChat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "08976da5f13c0a1031e1124fb5376ebdecf7421982366902aee1e63adc5844be",
+  "originHash" : "82bda97c4f4daad8b8e2d9624cfc24da13604afa4325528017e4068ead79b258",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "3744a4807d8c05fabdee46fd439629b51703ed75",
-        "version" : "1.2.48"
+        "revision" : "4e23a5136ecaf40fa7bad9b0df6bb5be5bb2b0c7",
+        "version" : "1.2.51"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "65e95a820fbb1de1fab1be4ca6a864f709557c3ffee01e1c990d82952793a06a",
+  "originHash" : "c5a311ec99a465212cd75bae8db1ca4164d5636e38f0e159f7b51ee8b32c8c1b",
   "pins" : [
     {
       "identity" : "ably-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ably/ably-cocoa",
       "state" : {
-        "revision" : "3744a4807d8c05fabdee46fd439629b51703ed75",
-        "version" : "1.2.48"
+        "revision" : "4e23a5136ecaf40fa7bad9b0df6bb5be5bb2b0c7",
+        "version" : "1.2.51"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         // This is the SDK's only dependency.
         .package(
             url: "https://github.com/ably/ably-cocoa",
-            from: "1.2.48",
+            from: "1.2.51",
         ),
 
         // All of the following dependencies are only used for internal purposes (testing or build tooling).

--- a/Tests/AblyChatTests/Mocks/MockAblyCocoaRealtime.swift
+++ b/Tests/AblyChatTests/Mocks/MockAblyCocoaRealtime.swift
@@ -167,6 +167,10 @@ final class MockAblyCocoaRealtime: NSObject, RealtimeClientProtocol, @unchecked 
             fatalError("Not implemented")
         }
 
+        var modes: ARTChannelMode {
+            fatalError("Not implemented")
+        }
+
         func publish(_: String?, data _: Any?) {
             fatalError("Not implemented")
         }
@@ -328,6 +332,30 @@ final class MockAblyCocoaRealtime: NSObject, RealtimeClientProtocol, @unchecked 
         }
 
         func unsubscribe(_: String, listener _: ARTEventListener) {
+            fatalError("Not implemented")
+        }
+
+        func publish(for _: ARTMessage, annotation _: ARTOutboundAnnotation, callback _: ARTCallback? = nil) {
+            fatalError("Not implemented")
+        }
+
+        func publish(forMessageSerial _: String, annotation _: ARTOutboundAnnotation, callback _: ARTCallback? = nil) {
+            fatalError("Not implemented")
+        }
+
+        func delete(for _: ARTMessage, annotation _: ARTOutboundAnnotation, callback _: ARTCallback? = nil) {
+            fatalError("Not implemented")
+        }
+
+        func delete(forMessageSerial _: String, annotation _: ARTOutboundAnnotation, callback _: ARTCallback? = nil) {
+            fatalError("Not implemented")
+        }
+
+        func getFor(_: ARTMessage, query _: ARTAnnotationsQuery, callback _: @escaping ARTPaginatedAnnotationsCallback) {
+            fatalError("Not implemented")
+        }
+
+        func getForMessageSerial(_: String, query _: ARTAnnotationsQuery, callback _: @escaping ARTPaginatedAnnotationsCallback) {
             fatalError("Not implemented")
         }
     }


### PR DESCRIPTION
Resolves #295 (see https://github.com/ably/ably-cocoa/commit/a513dd5ac5b50a8e4c2794fc8209d5001c4eb4e9).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Ably Cocoa SDK dependency to version 1.2.51 — the app now uses the newer Ably Cocoa runtime across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->