### PR TITLE
Release version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.1.0](https://github.com/ably/ably-chat-swift/tree/1.1.0)
+
+### Bug Fixes
+
+- **Connection Status**: Added missing `closing` and `closed` states to the `ConnectionStatus` enum. Previously these states were incorrectly mapped to `failed`. [#466](https://github.com/ably/ably-chat-swift/pull/466)
+
 ## [1.0.1](https://github.com/ably/ably-chat-swift/tree/1.0.1)
 
 ### What's Changed

--- a/Sources/AblyChat/Version.swift
+++ b/Sources/AblyChat/Version.swift
@@ -3,7 +3,7 @@ import Ably
 /// Information about the Chat SDK.
 internal enum ClientInformation {
     /// The version number of this version of the Chat SDK.
-    internal static let version = "1.0.1"
+    internal static let version = "1.1.0"
 
     /// The agents to pass to `createWrapperSDKProxy` per CHA-IN1b.
     internal static let agents = ["chat-swift": Self.version]


### PR DESCRIPTION
This is technically a breaking change in that it breaks exhaustive switching over the `ConnectionStatus` enum. However given that we're very early days on v1, we've decided to consider this an "obvious mistake" bug and address it across all platforms. Internal discussion [here](https://ably-real-time.slack.com/archives/C02NY1VT3LY/p1761576788131929).

Changelog text taken from https://github.com/ably/ably-chat-js/pull/688/commits/cb1bdcdbb39ed3fed83e64a72785c5bf985633ec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced connection status tracking with improved state differentiation, introducing distinct handling for connection closing and closed scenarios that were previously consolidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->