### PR TITLE
type erased MessageSubscription allowing users to pass around a MessageSubscription property

### DIFF
--- a/Sources/AblyChat/MessageSubscription.swift
+++ b/Sources/AblyChat/MessageSubscription.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+/// A concrete type for message subscriptions that can be used for type annotations and passed to functions.
+///
+/// This type provides the same functionality as the underlying `MessageSubscriptionResponseAsyncSequence`
+/// but without generic parameters, making it easy to store, pass around, and use as a property type.
+///
+/// This mirrors the `MessageSubscriptionResponse` interface in JavaScript and `MessagesSubscription` in Kotlin,
+/// providing Swift developers with a simple, explicit type for message subscriptions.
+///
+/// Example usage:
+/// ```swift
+/// class ChatManager {
+///     var subscription: MessageSubscription?
+///
+///     func setup(room: some Room) async {
+///         subscription = MessageSubscription(room.messages.subscribe())
+///     }
+///
+///     func processMessages(_ subscription: MessageSubscription) async {
+///         let history = try? await subscription.historyBeforeSubscribe(withParams: .init())
+///         for await event in subscription {
+///             print(event.message.text)
+///         }
+///     }
+/// }
+/// ```
+public final class MessageSubscription: Sendable, AsyncSequence {
+    // swiftlint:disable:next missing_docs
+    public typealias Element = ChatMessageEvent
+
+    private let box: any MessageSubscriptionBox
+
+    /// Creates a `MessageSubscription` by wrapping a `MessageSubscriptionResponseAsyncSequence`.
+    ///
+    /// This initializer type-erases the generic `HistoryResult` parameter, allowing
+    /// the resulting `MessageSubscription` to be used as a concrete type.
+    ///
+    /// - Parameter underlying: The `MessageSubscriptionResponseAsyncSequence` to wrap.
+    public init(_ underlying: MessageSubscriptionResponseAsyncSequence<some PaginatedResult<Message>>) {
+        box = ConcreteMessageSubscriptionBox(underlying)
+    }
+
+    /// Creates a `MessageSubscription` for testing/mocking purposes.
+    ///
+    /// - Parameters:
+    ///   - mockAsyncSequence: An `AsyncSequence` that provides the events.
+    ///   - mockHistoryBeforeSubscribe: A closure that returns paginated history results.
+    public init<Underlying: AsyncSequence & Sendable>(
+        mockAsyncSequence: Underlying,
+        mockHistoryBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>,
+    ) where Underlying.Element == Element {
+        box = MockMessageSubscriptionBox(
+            asyncSequence: mockAsyncSequence,
+            historyBeforeSubscribe: mockHistoryBeforeSubscribe,
+        )
+    }
+
+    /// Get the previous messages that were sent to the room before the listener was subscribed.
+    ///
+    /// If the client experiences a discontinuity event (i.e. the connection was lost and could not be resumed),
+    /// the starting point of historyBeforeSubscribe will be reset.
+    ///
+    /// Calls to historyBeforeSubscribe will wait for continuity to be restored before resolving.
+    ///
+    /// Once continuity is restored, the subscription point will be set to the beginning of this new period
+    /// of continuity. To ensure that no messages are missed, you should call historyBeforeSubscribe after
+    /// any period of discontinuity to fill any gaps in the message history.
+    ///
+    /// - Parameter params: Parameters for the history query.
+    /// - Returns: A paginated result of messages, in newest-to-oldest order.
+    public func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message> {
+        switch box {
+        case let wrapped as ConcreteMessageSubscriptionBox:
+            try await wrapped.historyBeforeSubscribe(withParams: params)
+        case let mock as MockMessageSubscriptionBox:
+            try await mock.historyBeforeSubscribe(withParams: params)
+        default:
+            fatalError("Unknown box type")
+        }
+    }
+
+    // MARK: - AsyncSequence conformance
+
+    // swiftlint:disable:next missing_docs
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        fileprivate var underlying: any MessageSubscriptionIteratorBox
+
+        // swiftlint:disable:next missing_docs
+        public mutating func next() async -> Element? {
+            await underlying.next()
+        }
+    }
+
+    // swiftlint:disable:next missing_docs
+    public func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(underlying: box.makeIterator())
+    }
+}
+
+// MARK: - Internal protocols for type erasure
+
+/// Protocol for type-erased message subscription box.
+private protocol MessageSubscriptionBox: Sendable {
+    func makeIterator() -> any MessageSubscriptionIteratorBox
+}
+
+/// Protocol for type-erased async iterator box.
+private protocol MessageSubscriptionIteratorBox {
+    mutating func next() async -> ChatMessageEvent?
+}
+
+// MARK: - Concrete box implementation
+
+/// Box that wraps a `MessageSubscriptionResponseAsyncSequence`.
+private final class ConcreteMessageSubscriptionBox: MessageSubscriptionBox, @unchecked Sendable {
+    private let underlying: any InternalMessageSubscriptionBox
+
+    init(_ underlying: MessageSubscriptionResponseAsyncSequence<some PaginatedResult<Message>>) {
+        self.underlying = TypedMessageSubscriptionBox(underlying)
+    }
+
+    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message> {
+        try await underlying.historyBeforeSubscribe(withParams: params)
+    }
+
+    func makeIterator() -> any MessageSubscriptionIteratorBox {
+        underlying.makeIterator()
+    }
+}
+
+/// Internal protocol to hide generic parameter.
+private protocol InternalMessageSubscriptionBox: Sendable {
+    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>
+    func makeIterator() -> any MessageSubscriptionIteratorBox
+}
+
+/// Typed box that holds the actual `MessageSubscriptionResponseAsyncSequence`.
+private final class TypedMessageSubscriptionBox<HistoryResult: PaginatedResult<Message>>: InternalMessageSubscriptionBox, @unchecked Sendable {
+    private let underlying: MessageSubscriptionResponseAsyncSequence<HistoryResult>
+
+    init(_ underlying: MessageSubscriptionResponseAsyncSequence<HistoryResult>) {
+        self.underlying = underlying
+    }
+
+    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message> {
+        try await underlying.historyBeforeSubscribe(withParams: params)
+    }
+
+    func makeIterator() -> any MessageSubscriptionIteratorBox {
+        ConcreteIteratorBox(underlying.makeAsyncIterator())
+    }
+
+    /// Box that wraps the concrete iterator.
+    private struct ConcreteIteratorBox: MessageSubscriptionIteratorBox {
+        private var iterator: MessageSubscriptionResponseAsyncSequence<HistoryResult>.AsyncIterator
+
+        init(_ iterator: MessageSubscriptionResponseAsyncSequence<HistoryResult>.AsyncIterator) {
+            self.iterator = iterator
+        }
+
+        mutating func next() async -> ChatMessageEvent? {
+            await iterator.next()
+        }
+    }
+}
+
+// MARK: - Mock box implementation
+
+/// Box for mock subscriptions used in testing.
+private final class MockMessageSubscriptionBox: MessageSubscriptionBox, @unchecked Sendable {
+    private let asyncSequence: MockAsyncSequenceBox
+    private let _historyBeforeSubscribe: @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>
+
+    init<Underlying: AsyncSequence & Sendable>(
+        asyncSequence: Underlying,
+        historyBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>,
+    ) where Underlying.Element == ChatMessageEvent {
+        self.asyncSequence = MockAsyncSequenceBox(asyncSequence)
+        _historyBeforeSubscribe = historyBeforeSubscribe
+    }
+
+    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message> {
+        try await _historyBeforeSubscribe(params)
+    }
+
+    func makeIterator() -> any MessageSubscriptionIteratorBox {
+        asyncSequence.makeIterator()
+    }
+}
+
+/// Type-erased box for mock async sequences.
+private final class MockAsyncSequenceBox: @unchecked Sendable {
+    private let _makeIterator: () -> any MessageSubscriptionIteratorBox
+
+    init<Underlying: AsyncSequence & Sendable>(_ sequence: Underlying) where Underlying.Element == ChatMessageEvent {
+        _makeIterator = {
+            MockIteratorBox(sequence.makeAsyncIterator())
+        }
+    }
+
+    func makeIterator() -> any MessageSubscriptionIteratorBox {
+        _makeIterator()
+    }
+
+    /// Box that wraps mock iterators.
+    private struct MockIteratorBox<I: AsyncIteratorProtocol>: MessageSubscriptionIteratorBox where I.Element == ChatMessageEvent {
+        private var iterator: I
+
+        init(_ iterator: I) {
+            self.iterator = iterator
+        }
+
+        mutating func next() async -> ChatMessageEvent? {
+            do {
+                return try await iterator.next()
+            } catch {
+                fatalError("The AsyncSequence passed to MessageSubscription.init(mockAsyncSequence:) threw an error: \(error). This is not supported.")
+            }
+        }
+    }
+}

--- a/Tests/AblyChatTests/MessageSubscriptionTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionTests.swift
@@ -1,0 +1,136 @@
+import Ably
+@testable import AblyChat
+import AsyncAlgorithms
+import Foundation
+import Testing
+
+private final class MockPaginatedResult: PaginatedResult, @unchecked Sendable {
+    let items: [Message]
+    let hasNext: Bool
+    let isLast: Bool
+
+    init(items: [Message] = [], hasNext: Bool = false) {
+        self.items = items
+        self.hasNext = hasNext
+        isLast = !hasNext
+    }
+
+    func next() async throws(ErrorInfo) -> MockPaginatedResult? { nil }
+    func first() async throws(ErrorInfo) -> MockPaginatedResult { self }
+    func current() async throws(ErrorInfo) -> MockPaginatedResult { self }
+}
+
+struct MessageSubscriptionTests {
+    let messages = ["First", "Second"].map { text in
+        Message(serial: "", action: .messageCreate, clientID: "", text: text, metadata: [:], headers: [:], version: .init(serial: "", timestamp: Date()), timestamp: Date(), reactions: .empty)
+    }
+
+    // MARK: - Type annotation tests (the main purpose of MessageSubscription)
+
+    @Test
+    @MainActor
+    func canBeUsedAsPropertyType() async {
+        // This test verifies that MessageSubscription can be used as a concrete property type
+        // without needing to specify generic parameters
+        final class ChatManager: Sendable {
+            let subscription: MessageSubscription
+
+            init(subscription: MessageSubscription) {
+                self.subscription = subscription
+            }
+        }
+
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let mockResult = MockPaginatedResult()
+        let subscription = MessageSubscription(
+            mockAsyncSequence: events.async,
+        ) { _ in mockResult }
+        let manager = ChatManager(subscription: subscription)
+        #expect(manager.subscription === subscription)
+    }
+
+    @Test
+    @MainActor
+    func canBeUsedAsParameterType() async {
+        // This test verifies that MessageSubscription can be used as a function parameter type
+        func processSubscription(_ sub: MessageSubscription) async -> [String] {
+            var texts: [String] = []
+            for await event in sub.prefix(2) {
+                texts.append(event.message.text)
+            }
+            return texts
+        }
+
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let mockResult = MockPaginatedResult()
+        let subscription = MessageSubscription(
+            mockAsyncSequence: events.async,
+        ) { _ in mockResult }
+        let texts = await processSubscription(subscription)
+        #expect(texts == ["First", "Second"])
+    }
+
+    @Test
+    @MainActor
+    func canBeUsedAsOptionalPropertyType() async {
+        // This test verifies that MessageSubscription? can be used as a property type
+        final class ChatManager: @unchecked Sendable {
+            var subscription: MessageSubscription?
+
+            func setSubscription(_ sub: MessageSubscription) {
+                subscription = sub
+            }
+        }
+
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let mockResult = MockPaginatedResult()
+        let subscription = MessageSubscription(
+            mockAsyncSequence: events.async,
+        ) { _ in mockResult }
+        let manager = ChatManager()
+        #expect(manager.subscription == nil)
+        manager.setSubscription(subscription)
+        #expect(manager.subscription != nil)
+    }
+
+    // MARK: - Functionality tests
+
+    @Test
+    @MainActor
+    func iteratingThroughMessages() async {
+        // Test that MessageSubscription properly provides messages via AsyncSequence
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let mockResult = MockPaginatedResult()
+        let subscription = MessageSubscription(
+            mockAsyncSequence: events.async,
+        ) { _ in mockResult }
+        #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
+    }
+
+    @Test
+    @MainActor
+    func historyBeforeSubscribe() async throws {
+        // Test that historyBeforeSubscribe returns the paginated result
+        let historyMessages = messages
+        let mockPaginatedResult = MockPaginatedResult(items: historyMessages)
+        let subscription = MessageSubscription(
+            mockAsyncSequence: [ChatMessageEvent]().async,
+        ) { _ in mockPaginatedResult }
+        let result = try await subscription.historyBeforeSubscribe(withParams: .init())
+        #expect(result.items.count == 2)
+        #expect(result.items[0].text == "First")
+    }
+
+    @Test
+    @MainActor
+    func wrappingMessageSubscriptionResponseAsyncSequence() async {
+        // Test that MessageSubscription properly wraps MessageSubscriptionResponseAsyncSequence
+        let events = messages.map { ChatMessageEvent(message: $0) }
+        let mockResult = MockPaginatedResult()
+        let underlying = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(
+            mockAsyncSequence: events.async,
+        ) { _ in mockResult }
+        let subscription = MessageSubscription(underlying)
+        #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
+    }
+}


### PR DESCRIPTION

  Implementation Details

  MessageSubscription (Sources/AblyChat/MessageSubscription.swift:27):
  - A final class conforming to Sendable and AsyncSequence
  - Two initializers:
    a. init(_ underlying:) - wraps a MessageSubscriptionResponseAsyncSequence<some PaginatedResult<Message>>
    b. init(mockAsyncSequence:mockHistoryBeforeSubscribe:) - for testing/mocking
  - Uses a box-based type erasure pattern with:
    - MessageSubscriptionBox protocol for type-erased storage
    - ConcreteMessageSubscriptionBox that wraps the real subscription
    - MockMessageSubscriptionBox for testing
  - The historyBeforeSubscribe method returns any PaginatedResult<Message> (existential type)

  Tests (Tests/AblyChatTests/MessageSubscriptionTests.swift):
  - 6 tests covering:
    - canBeUsedAsPropertyType() - verifies explicit type annotations work
    - canBeUsedAsParameterType() - verifies use as function parameters
    - canBeUsedAsOptionalPropertyType() - verifies optional property usage
    - iteratingThroughMessages() - verifies AsyncSequence conformance
    - historyBeforeSubscribe() - verifies history retrieval
    - wrappingMessageSubscriptionResponseAsyncSequence() - verifies wrapping works

  Expected Usage

```
  import AblyChat

  class ChatManager {
      var messageSubscription: MessageSubscription?  // ✅ Can use as property type

      func setup(room: some Room) async throws {
          messageSubscription = MessageSubscription(room.messages.subscribe())
      }

      func processMessages(_ subscription: MessageSubscription) async {  // ✅ Can use as parameter
          for await event in subscription {  // ✅ Can iterate as AsyncSequence
              print(event.message.text)
          }
      }
  }

```

