### PR TITLE
Concrete PaginatedResult which allows us to then return a concrete MessageSubscription

### DIFF
--- a/Sources/AblyChat/ChatAPI.swift
+++ b/Sources/AblyChat/ChatAPI.swift
@@ -47,7 +47,7 @@ internal final class ChatAPI<Realtime: InternalRealtimeClientProtocol> {
     }
 
     // (CHA-M6) Messages should be queryable from a paginated REST API.
-    internal func getMessages(roomName: String, params: HistoryParams) async throws(ErrorInfo) -> DefaultPaginatedResult<Realtime.HTTPPaginatedResponse, Message> {
+    internal func getMessages(roomName: String, params: HistoryParams) async throws(ErrorInfo) -> PaginatedResult<Message> {
         let endpoint = roomUrl(roomName: roomName, suffix: "/messages")
         return try await makePaginatedRequest(endpoint, params: params.asQueryItems())
     }
@@ -218,8 +218,8 @@ internal final class ChatAPI<Realtime: InternalRealtimeClientProtocol> {
     private func makePaginatedRequest<Item: JSONDecodable & Sendable>(
         _ url: String,
         params: [String: String]? = nil,
-    ) async throws(ErrorInfo) -> DefaultPaginatedResult<Realtime.HTTPPaginatedResponse, Item> {
+    ) async throws(ErrorInfo) -> PaginatedResult<Item> {
         let paginatedResponse = try await realtime.request("GET", path: url, params: params, body: nil, headers: [:])
-        return try DefaultPaginatedResult(response: paginatedResponse)
+        return try PaginatedResult(response: paginatedResponse)
     }
 }

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -115,7 +115,7 @@ internal final class DefaultMessages<Realtime: InternalRealtimeClientProtocol>: 
     }
 
     // (CHA-M6a) A method must be exposed that accepts the standard Ably REST API query parameters. It shall call the "REST API"#rest-fetching-messages and return a PaginatedResult containing messages, which can then be paginated through.
-    internal func history(withParams params: HistoryParams) async throws(ErrorInfo) -> some PaginatedResult<Message> {
+    internal func history(withParams params: HistoryParams) async throws(ErrorInfo) -> PaginatedResult<Message> {
         try await chatAPI.getMessages(roomName: roomName, params: params)
     }
 

--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -12,8 +12,6 @@ public protocol Messages: AnyObject, Sendable {
     associatedtype Reactions: MessageReactions
     // swiftlint:disable:next missing_docs
     associatedtype SubscribeResponse: MessageSubscriptionResponse
-    // swiftlint:disable:next missing_docs
-    associatedtype HistoryResult: PaginatedResult<Message>
 
     /**
      * Subscribe to new messages in this chat room.
@@ -33,7 +31,7 @@ public protocol Messages: AnyObject, Sendable {
      *
      * - Returns: A paginated result object that can be used to fetch more messages if available.
      */
-    func history(withParams params: HistoryParams) async throws(ErrorInfo) -> HistoryResult
+    func history(withParams params: HistoryParams) async throws(ErrorInfo) -> PaginatedResult<Message>
 
     /**
      * Send a message in the chat room.
@@ -125,13 +123,13 @@ public extension Messages {
      *
      * - Returns: A subscription ``MessageSubscription`` that can be used to iterate through new messages.
      */
-    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscription {
         var emitEvent: ((ChatMessageEvent) -> Void)?
         let subscription = subscribe { event in
             emitEvent?(event)
         }
 
-        let subscriptionAsyncSequence = MessageSubscriptionResponseAsyncSequence(
+        let subscriptionAsyncSequence = MessageSubscription(
             bufferingPolicy: bufferingPolicy,
             historyBeforeSubscribe: subscription.historyBeforeSubscribe,
         )
@@ -149,7 +147,7 @@ public extension Messages {
     }
 
     /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
-    func subscribe() -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe() -> MessageSubscription {
         subscribe(bufferingPolicy: .unbounded)
     }
 }
@@ -406,32 +404,60 @@ public struct ChatMessageEvent: Sendable {
     }
 }
 
-/// A non-throwing `AsyncSequence` whose element is ``ChatMessageEvent``. The Chat SDK uses this type as the return value of the `AsyncSequence` convenience variants of the ``Messages`` methods that allow you to find out about received chat messages.
+/// A concrete type for message subscriptions that can be used for type annotations and passed to functions.
 ///
-/// You should only iterate over a given `MessageSubscriptionResponseAsyncSequence` once; the results of iterating more than once are undefined.
-public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: PaginatedResult<Message>>: Sendable, AsyncSequence {
+/// This type provides iteration over chat message events via `AsyncSequence` and access to
+/// message history before the subscription started via `historyBeforeSubscribe`.
+///
+/// Example usage:
+/// ```swift
+/// class ChatManager {
+///     var subscription: MessageSubscription?
+///
+///     func setup(room: some Room) async {
+///         subscription = room.messages.subscribe()
+///     }
+///
+///     func processMessages(_ subscription: MessageSubscription) async {
+///         let history = try? await subscription.historyBeforeSubscribe(withParams: .init())
+///         for await event in subscription {
+///             print(event.message.text)
+///         }
+///     }
+/// }
+/// ```
+///
+/// You should only iterate over a given `MessageSubscription` once; the results of iterating more than once are undefined.
+public final class MessageSubscription: Sendable, AsyncSequence {
     // swiftlint:disable:next missing_docs
     public typealias Element = ChatMessageEvent
 
     private let subscription: SubscriptionAsyncSequence<Element>
 
     // can be set by either initialiser
-    private let historyBeforeSubscribe: @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult
+    private let _historyBeforeSubscribe: @MainActor @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message>
 
     // used internally
     internal init(
         bufferingPolicy: BufferingPolicy,
-        historyBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult,
+        historyBeforeSubscribe: @escaping @MainActor @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message>,
     ) {
         subscription = .init(bufferingPolicy: bufferingPolicy)
-        self.historyBeforeSubscribe = historyBeforeSubscribe
+        _historyBeforeSubscribe = historyBeforeSubscribe
     }
 
     // used for testing
-    // swiftlint:disable:next missing_docs
-    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockHistoryBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult) where Underlying.Element == Element {
+    /// Creates a `MessageSubscription` for testing/mocking purposes.
+    ///
+    /// - Parameters:
+    ///   - mockAsyncSequence: An `AsyncSequence` that provides the events.
+    ///   - mockHistoryBeforeSubscribe: A closure that returns paginated history results.
+    public init<Underlying: AsyncSequence & Sendable>(
+        mockAsyncSequence: Underlying,
+        mockHistoryBeforeSubscribe: @escaping @MainActor @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message>,
+    ) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
-        historyBeforeSubscribe = mockHistoryBeforeSubscribe
+        _historyBeforeSubscribe = mockHistoryBeforeSubscribe
     }
 
     internal func emit(_ element: Element) {
@@ -443,9 +469,12 @@ public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: Pagin
         subscription.addTerminationHandler(onTermination)
     }
 
-    // swiftlint:disable:next missing_docs
-    public func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult {
-        try await historyBeforeSubscribe(params)
+    /// Get the previous messages that were sent to the room before the listener was subscribed.
+    ///
+    /// - Parameter params: Parameters for the history query.
+    /// - Returns: A paginated result of messages, in newest-to-oldest order.
+    public func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message> {
+        try await _historyBeforeSubscribe(params)
     }
 
     // swiftlint:disable:next missing_docs

--- a/Sources/AblyChat/PaginatedResult.swift
+++ b/Sources/AblyChat/PaginatedResult.swift
@@ -1,79 +1,114 @@
 import Ably
 
-// This disable of attributes can be removed once missing_docs fixed here
-// swiftlint:disable attributes
+/// A paginated result containing items of a specific type.
+///
+/// This class provides pagination functionality for query results from the Ably Chat API.
+/// You can iterate through pages using the `next()`, `first()`, and `current()` methods.
+///
+/// For testing purposes, you can create instances using the public initializer:
+/// ```swift
+/// let mockResult = PaginatedResult(
+///     items: [message1, message2],
+///     hasNext: false
+/// )
+/// ```
 @MainActor
-// swiftlint:disable:next missing_docs
-public protocol PaginatedResult<Item>: AnyObject, Sendable {
-    // swiftlint:enable attributes
+public final class PaginatedResult<Item: Sendable> {
+    /// The items contained in the current page.
+    public let items: [Item]
 
-    // swiftlint:disable:next missing_docs
-    associatedtype Item
+    /// Whether there is a next page available.
+    public let hasNext: Bool
 
-    // swiftlint:disable:next missing_docs
-    var items: [Item] { get }
-    // swiftlint:disable:next missing_docs
-    var hasNext: Bool { get }
-    // swiftlint:disable:next missing_docs
-    var isLast: Bool { get }
-    // swiftlint:disable:next missing_docs
-    func next() async throws(ErrorInfo) -> Self?
-    // swiftlint:disable:next missing_docs
-    func first() async throws(ErrorInfo) -> Self
-    // swiftlint:disable:next missing_docs
-    func current() async throws(ErrorInfo) -> Self
-}
+    /// Whether this is the last page.
+    public let isLast: Bool
 
-/// `PaginatedResult` protocol implementation that wraps an `InternalHTTPPaginatedResponseProtocol` and converts its items to the desired type.
-@MainActor
-internal final class DefaultPaginatedResult<Underlying: InternalHTTPPaginatedResponseProtocol, Item: JSONDecodable & Sendable>: PaginatedResult {
-    internal let items: [Item]
-    internal let hasNext: Bool
-    internal let isLast: Bool
-    private let underlying: Underlying
+    // Internal storage for pagination operations
+    private let nextProvider: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>?)?
+    private let firstProvider: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>)?
 
-    internal init(underlying: Underlying, items: [Item]) {
-        self.underlying = underlying
+    /// Creates a `PaginatedResult` for testing or mocking purposes.
+    ///
+    /// - Parameters:
+    ///   - items: The items in this page.
+    ///   - hasNext: Whether there is a next page. Defaults to `false`.
+    ///   - isLast: Whether this is the last page. Defaults to `!hasNext`.
+    ///   - next: Optional closure to provide the next page. If `nil` and `hasNext` is `true`,
+    ///           calling `next()` will return `nil`.
+    ///   - first: Optional closure to provide the first page. If `nil`, calling `first()`
+    ///            will return `self`.
+    public init(
+        items: [Item],
+        hasNext: Bool = false,
+        isLast: Bool? = nil,
+        next: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>?)? = nil,
+        first: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>)? = nil,
+    ) {
         self.items = items
-        hasNext = underlying.hasNext
-        isLast = underlying.isLast
+        self.hasNext = hasNext
+        self.isLast = isLast ?? !hasNext
+        nextProvider = next
+        firstProvider = first
     }
 
-    /// Convenience initializer that checks status code and decodes items from the response.
-    internal convenience init(response: Underlying) throws(ErrorInfo) {
+    /// Internal initializer for creating from HTTP responses.
+    internal init(
+        response: some InternalHTTPPaginatedResponseProtocol,
+    ) throws(ErrorInfo) where Item: JSONDecodable {
         // TODO: We've had this check since the start of the codebase, but it's not specified anywhere; rectify this in https://github.com/ably/ably-chat-swift/issues/453
         guard response.statusCode == 200 else {
             throw InternalError.paginatedResultStatusCode(response.statusCode).toErrorInfo()
         }
 
-        let items = try response.items.map { jsonValue throws(ErrorInfo) in
+        items = try response.items.map { jsonValue throws(ErrorInfo) in
             try Item(jsonValue: jsonValue)
         }
+        hasNext = response.hasNext
+        isLast = response.isLast
 
-        self.init(underlying: response, items: items)
-    }
-
-    /// Asynchronously fetch the next page if available
-    internal func next() async throws(ErrorInfo) -> DefaultPaginatedResult<Underlying, Item>? {
-        guard let nextUnderlying = try await underlying.next() else {
-            return nil
+        // Capture response for pagination
+        nextProvider = { @MainActor [response] () async throws(ErrorInfo) -> PaginatedResult<Item>? in
+            guard let nextResponse = try await response.next() else {
+                return nil
+            }
+            return try PaginatedResult<Item>(response: nextResponse)
         }
-        return try DefaultPaginatedResult(response: nextUnderlying)
+        firstProvider = { @MainActor [response] () async throws(ErrorInfo) -> PaginatedResult<Item> in
+            try await PaginatedResult<Item>(response: response.first())
+        }
     }
 
-    /// Asynchronously fetch the first page
-    internal func first() async throws(ErrorInfo) -> DefaultPaginatedResult<Underlying, Item> {
-        try await DefaultPaginatedResult(response: underlying.first())
+    /// Fetches the next page of results.
+    ///
+    /// - Returns: The next page, or `nil` if there are no more pages.
+    public func next() async throws(ErrorInfo) -> PaginatedResult<Item>? {
+        if let nextProvider {
+            return try await nextProvider()
+        }
+        return nil
     }
 
-    /// Asynchronously fetch the current page
-    internal func current() async throws(ErrorInfo) -> DefaultPaginatedResult<Underlying, Item> {
+    /// Fetches the first page of results.
+    ///
+    /// - Returns: The first page.
+    public func first() async throws(ErrorInfo) -> PaginatedResult<Item> {
+        if let firstProvider {
+            return try await firstProvider()
+        }
+        return self
+    }
+
+    /// Returns the current page.
+    ///
+    /// - Returns: This page (self).
+    public func current() async throws(ErrorInfo) -> PaginatedResult<Item> {
         self
     }
 }
 
-extension DefaultPaginatedResult: Equatable where Item: Equatable {
-    internal nonisolated static func == (lhs: DefaultPaginatedResult<Underlying, Item>, rhs: DefaultPaginatedResult<Underlying, Item>) -> Bool {
+extension PaginatedResult: Equatable where Item: Equatable {
+    // swiftlint:disable:next missing_docs
+    public nonisolated static func == (lhs: PaginatedResult<Item>, rhs: PaginatedResult<Item>) -> Bool {
         lhs.items == rhs.items &&
             lhs.hasNext == rhs.hasNext &&
             lhs.isLast == rhs.isLast

--- a/Sources/AblyChat/Subscription.swift
+++ b/Sources/AblyChat/Subscription.swift
@@ -34,9 +34,6 @@ public protocol StatusSubscription: Sendable {
  */
 @MainActor
 public protocol MessageSubscriptionResponse: Subscription, Sendable {
-    // swiftlint:disable:next missing_docs
-    associatedtype HistoryResult: PaginatedResult<Message>
-
     /**
      * Get the previous messages that were sent to the room before the listener was subscribed.
      *
@@ -54,7 +51,7 @@ public protocol MessageSubscriptionResponse: Subscription, Sendable {
      *
      * - Returns: A paginated result of messages, in newest-to-oldest order.
      */
-    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult
+    func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message>
 }
 
 internal struct DefaultSubscription: Subscription, Sendable {
@@ -91,7 +88,7 @@ internal struct DefaultMessageSubscriptionResponse<Realtime: InternalRealtimeCli
         _unsubscribe()
     }
 
-    internal func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> some PaginatedResult<Message> {
+    internal func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> PaginatedResult<Message> {
         let fromSerial = try await subscriptionStartSerial()
 
         // (CHA-M5f) This method must accept any of the standard history query options, except for direction

--- a/Tests/AblyChatTests/ChatAPITests.swift
+++ b/Tests/AblyChatTests/ChatAPITests.swift
@@ -116,16 +116,14 @@ struct ChatAPITests {
         }
         let chatAPI = ChatAPI(realtime: realtime)
         let roomName = "basketball"
-        let expectedPaginatedResult = DefaultPaginatedResult<MockHTTPPaginatedResponse, Message>(
-            underlying: paginatedResponse,
-            items: [],
-        )
 
         // When
         let getMessages = try await chatAPI.getMessages(roomName: roomName, params: .init())
 
         // Then
-        #expect(getMessages == expectedPaginatedResult)
+        #expect(getMessages.items.isEmpty)
+        #expect(getMessages.hasNext == paginatedResponse.hasNext)
+        #expect(getMessages.isLast == paginatedResponse.isLast)
     }
 
     // @specOneOf(2/2) CHA-M6
@@ -138,39 +136,38 @@ struct ChatAPITests {
         }
         let chatAPI = ChatAPI(realtime: realtime)
         let roomName = "basketball"
-        let expectedPaginatedResult = DefaultPaginatedResult<MockHTTPPaginatedResponse, Message>(
-            underlying: paginatedResponse,
-            items: [
-                Message(
-                    serial: "123456789-000@123456789:000",
-                    action: .messageCreate,
-                    clientID: "random",
-                    text: "hello",
-                    metadata: [:],
-                    headers: [:],
-                    version: .init(serial: "123456789-000@123456789:000", timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)), // from successGetMessagesWithItems
-                    timestamp: Date(timeIntervalSince1970: 1_730_943_049.269),
-                    reactions: .empty,
-                ),
-                Message(
-                    serial: "123456789-000@123456789:001",
-                    action: .messageCreate,
-                    clientID: "random",
-                    text: "hello response",
-                    metadata: [:],
-                    headers: [:],
-                    version: .init(serial: "123456789-000@123456789:001", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)),
-                    timestamp: Date(timeIntervalSince1970: 1_730_943_051.269),
-                    reactions: .empty,
-                ),
-            ],
-        )
+        let expectedMessages = [
+            Message(
+                serial: "123456789-000@123456789:000",
+                action: .messageCreate,
+                clientID: "random",
+                text: "hello",
+                metadata: [:],
+                headers: [:],
+                version: .init(serial: "123456789-000@123456789:000", timestamp: Date(timeIntervalSince1970: 1_730_943_049.269)), // from successGetMessagesWithItems
+                timestamp: Date(timeIntervalSince1970: 1_730_943_049.269),
+                reactions: .empty,
+            ),
+            Message(
+                serial: "123456789-000@123456789:001",
+                action: .messageCreate,
+                clientID: "random",
+                text: "hello response",
+                metadata: [:],
+                headers: [:],
+                version: .init(serial: "123456789-000@123456789:001", timestamp: Date(timeIntervalSince1970: 1_730_943_051.269)),
+                timestamp: Date(timeIntervalSince1970: 1_730_943_051.269),
+                reactions: .empty,
+            ),
+        ]
 
         // When
         let getMessagesResult = try await chatAPI.getMessages(roomName: roomName, params: .init())
 
         // Then
-        #expect(getMessagesResult == expectedPaginatedResult)
+        #expect(getMessagesResult.items == expectedMessages)
+        #expect(getMessagesResult.hasNext == paginatedResponse.hasNext)
+        #expect(getMessagesResult.isLast == paginatedResponse.isLast)
     }
 
     // @spec CHA-M5i

--- a/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
@@ -4,28 +4,6 @@ import AsyncAlgorithms
 import Foundation
 import Testing
 
-private final class MockPaginatedResult<Item: Equatable>: PaginatedResult, @MainActor Equatable {
-    var items: [Item] { fatalError("Not implemented") }
-
-    var hasNext: Bool { fatalError("Not implemented") }
-
-    var isLast: Bool { fatalError("Not implemented") }
-
-    func next() async throws(ErrorInfo) -> MockPaginatedResult<Item>? { fatalError("Not implemented") }
-
-    func first() async throws(ErrorInfo) -> MockPaginatedResult<Item> { fatalError("Not implemented") }
-
-    func current() async throws(ErrorInfo) -> MockPaginatedResult<Item> { fatalError("Not implemented") }
-
-    init() {}
-
-    static func == (lhs: MockPaginatedResult<Item>, rhs: MockPaginatedResult<Item>) -> Bool {
-        lhs.items == rhs.items &&
-            lhs.hasNext == rhs.hasNext &&
-            lhs.isLast == rhs.isLast
-    }
-}
-
 struct MessageSubscriptionResponseAsyncSequenceTests {
     let messages = ["First", "Second"].map { text in
         Message(serial: "", action: .messageCreate, clientID: "", text: text, metadata: [:], headers: [:], version: .init(serial: "", timestamp: Date()), timestamp: Date(), reactions: .empty)
@@ -34,13 +12,18 @@ struct MessageSubscriptionResponseAsyncSequenceTests {
     @Test
     func withMockAsyncSequence() async {
         let events = messages.map { ChatMessageEvent(message: $0) }
-        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscription(mockAsyncSequence: events.async) { _ in
+            PaginatedResult(items: [])
+        }
         #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
     }
 
     @Test
+    @MainActor
     func emit() async {
-        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscription(
+            bufferingPolicy: .unbounded,
+        ) { _ in PaginatedResult(items: []) }
         async let emittedElements = Array(subscription.prefix(2))
         subscription.emit(ChatMessageEvent(message: messages[0]))
         subscription.emit(ChatMessageEvent(message: messages[1]))
@@ -50,10 +33,10 @@ struct MessageSubscriptionResponseAsyncSequenceTests {
     @Test
     @MainActor
     func mockGetPreviousMessages() async throws {
-        let mockPaginatedResult = MockPaginatedResult<Message>()
-        let subscription = MessageSubscriptionResponseAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
+        let mockPaginatedResult = PaginatedResult<Message>(items: messages)
+        let subscription = MessageSubscription(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
         let result = try await subscription.historyBeforeSubscribe(withParams: .init())
-        #expect(result === mockPaginatedResult)
+        #expect(result == mockPaginatedResult)
     }
 }


### PR DESCRIPTION

  This PR converts PaginatedResult from a protocol to a concrete class and renames MessageSubscriptionResponseAsyncSequence to MessageSubscription, removing the need for associated types that made these types difficult to use in practice.

  Motivation

  The previous protocol-based design with associated types made it challenging to:

  - Store subscriptions as properties: You couldn't easily write var subscription: MessageSubscription because MessageSubscriptionResponseAsyncSequence was generic over HistoryResult: PaginatedResult<Message>
  - Pass subscriptions to functions: Functions accepting subscriptions required complex generic signatures
  - Use in type annotations: The associated types cascaded through the type system, making simple patterns unnecessarily complex

  For example, this wasn't possible before:
```
  class ChatManager {
      var subscription: MessageSubscription?  // ❌ Couldn't do this

      func processMessages(_ subscription: MessageSubscription) async {  // ❌ Or this
          // ...
      }
  }
```

  Changes

  PaginatedResult - Protocol → Concrete Class

  - Changed from protocol PaginatedResult<Item> to public final class PaginatedResult<Item: Sendable>
  - Added public initializer for testing/mocking:
  public init(
      items: [Item],
      hasNext: Bool = false,
      isLast: Bool? = nil,
      next: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>?)? = nil,
      first: (@MainActor @Sendable () async throws(ErrorInfo) -> PaginatedResult<Item>)? = nil
  )
  - Pagination logic now uses closures internally rather than wrapping an underlying response type
  - Removed internal DefaultPaginatedResult class (no longer needed)

  MessageSubscription - Renamed and De-genericized

  - Renamed MessageSubscriptionResponseAsyncSequence<HistoryResult> → MessageSubscription
  - Removed generic parameter - now uses concrete PaginatedResult<Message> directly
  - Added documentation with usage examples

  Protocol Simplifications

  - Messages protocol: Removed associatedtype HistoryResult, history() now returns concrete PaginatedResult<Message>
  - MessageSubscriptionResponse protocol: Removed associatedtype HistoryResult, historyBeforeSubscribe() now returns concrete PaginatedResult<Message>

  Test Improvements

  - Removed MockPaginatedResult test helper - tests now use PaginatedResult directly with its public initializer
  - Simplified test assertions to compare items, hasNext, and isLast directly

  API Changes

  | Before                                                  | After                    |
  |---------------------------------------------------------|--------------------------|
  | some PaginatedResult<Message>                           | PaginatedResult<Message> |
  | MessageSubscriptionResponseAsyncSequence<HistoryResult> | MessageSubscription      |
  | associatedtype HistoryResult: PaginatedResult<Message>  | (removed)                |

  Example Usage (Now Possible)
```
  class ChatManager {
      var subscription: MessageSubscription?

      func setup(room: some Room) async {
          subscription = room.messages.subscribe()
      }

      func processMessages(_ subscription: MessageSubscription) async {
          let history = try? await subscription.historyBeforeSubscribe(withParams: .init())
          for await event in subscription {
              print(event.message.text)
          }
      }
  }
```
