### PR TITLE
[FTF-453] Remove generic parameter from MessageSubscriptionResponseAsyncSequence

### DIFF
--- a/Sources/AblyChat/Messages.swift
+++ b/Sources/AblyChat/Messages.swift
@@ -125,7 +125,7 @@ public extension Messages {
      *
      * - Returns: A subscription ``MessageSubscription`` that can be used to iterate through new messages.
      */
-    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe(bufferingPolicy: BufferingPolicy) -> MessageSubscriptionResponseAsyncSequence {
         var emitEvent: ((ChatMessageEvent) -> Void)?
         let subscription = subscribe { event in
             emitEvent?(event)
@@ -133,8 +133,9 @@ public extension Messages {
 
         let subscriptionAsyncSequence = MessageSubscriptionResponseAsyncSequence(
             bufferingPolicy: bufferingPolicy,
-            historyBeforeSubscribe: subscription.historyBeforeSubscribe,
-        )
+        ) { params throws(ErrorInfo) in
+            try await subscription.historyBeforeSubscribe(withParams: params)
+        }
         emitEvent = { [weak subscriptionAsyncSequence] event in
             subscriptionAsyncSequence?.emit(event)
         }
@@ -149,7 +150,7 @@ public extension Messages {
     }
 
     /// Same as calling ``subscribe(bufferingPolicy:)`` with ``BufferingPolicy/unbounded``.
-    func subscribe() -> MessageSubscriptionResponseAsyncSequence<SubscribeResponse.HistoryResult> {
+    func subscribe() -> MessageSubscriptionResponseAsyncSequence {
         subscribe(bufferingPolicy: .unbounded)
     }
 }
@@ -409,19 +410,35 @@ public struct ChatMessageEvent: Sendable {
 /// A non-throwing `AsyncSequence` whose element is ``ChatMessageEvent``. The Chat SDK uses this type as the return value of the `AsyncSequence` convenience variants of the ``Messages`` methods that allow you to find out about received chat messages.
 ///
 /// You should only iterate over a given `MessageSubscriptionResponseAsyncSequence` once; the results of iterating more than once are undefined.
-public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: PaginatedResult<Message>>: Sendable, AsyncSequence {
+public final class MessageSubscriptionResponseAsyncSequence: Sendable, AsyncSequence {
+    /*
+     Design note: Unlike other SDK types, this is a concrete class rather than a protocol. Ideally, for
+     consistency with the rest of the SDK, this would be a protocol that users could reference as
+     `any MessageSubscriptionResponseAsyncSequence`. However, creating an AsyncSequence-inheriting protocol
+     that allows iteration without `try` on an existential requires the `Failure` associated type, which is
+     only available in iOS 18+.
+
+     Additionally, this class intentionally has no generic parameters, even though the underlying implementation
+     uses concrete PaginatedResult types. This is because the type is impossible for users to spell due to Swift
+     compiler limitations with opaque types — attempting to write
+     `MessageSubscriptionResponseAsyncSequence<ChatClient.Rooms.Room.Messages.HistoryResult>` fails with
+     "Underlying type for opaque result type 'some Rooms<...>' could not be inferred from return expression".
+     By removing the generic parameter and having `historyBeforeSubscribe(withParams:)` return
+     `any PaginatedResult<Message>`, users can store subscriptions as simple properties
+     (e.g., `var subscription: MessageSubscriptionResponseAsyncSequence?`).
+     */
     // swiftlint:disable:next missing_docs
     public typealias Element = ChatMessageEvent
 
     private let subscription: SubscriptionAsyncSequence<Element>
 
     // can be set by either initialiser
-    private let historyBeforeSubscribe: @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult
+    private let historyBeforeSubscribe: @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>
 
     // used internally
     internal init(
         bufferingPolicy: BufferingPolicy,
-        historyBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult,
+        historyBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>,
     ) {
         subscription = .init(bufferingPolicy: bufferingPolicy)
         self.historyBeforeSubscribe = historyBeforeSubscribe
@@ -429,7 +446,7 @@ public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: Pagin
 
     // used for testing
     // swiftlint:disable:next missing_docs
-    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockHistoryBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult) where Underlying.Element == Element {
+    public init<Underlying: AsyncSequence & Sendable>(mockAsyncSequence: Underlying, mockHistoryBeforeSubscribe: @escaping @Sendable (HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message>) where Underlying.Element == Element {
         subscription = .init(mockAsyncSequence: mockAsyncSequence)
         historyBeforeSubscribe = mockHistoryBeforeSubscribe
     }
@@ -444,7 +461,7 @@ public final class MessageSubscriptionResponseAsyncSequence<HistoryResult: Pagin
     }
 
     // swiftlint:disable:next missing_docs
-    public func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> HistoryResult {
+    public func historyBeforeSubscribe(withParams params: HistoryBeforeSubscribeParams) async throws(ErrorInfo) -> any PaginatedResult<Message> {
         try await historyBeforeSubscribe(params)
     }
 

--- a/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionResponseAsyncSequenceTests.swift
@@ -34,13 +34,13 @@ struct MessageSubscriptionResponseAsyncSequenceTests {
     @Test
     func withMockAsyncSequence() async {
         let events = messages.map { ChatMessageEvent(message: $0) }
-        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscriptionResponseAsyncSequence(mockAsyncSequence: events.async) { _ in fatalError("Not implemented") }
         #expect(await Array(subscription.prefix(2)).map(\.message.text) == ["First", "Second"])
     }
 
     @Test
     func emit() async {
-        let subscription = MessageSubscriptionResponseAsyncSequence<MockPaginatedResult>(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
+        let subscription = MessageSubscriptionResponseAsyncSequence(bufferingPolicy: .unbounded) { _ in fatalError("Not implemented") }
         async let emittedElements = Array(subscription.prefix(2))
         subscription.emit(ChatMessageEvent(message: messages[0]))
         subscription.emit(ChatMessageEvent(message: messages[1]))
@@ -54,6 +54,6 @@ struct MessageSubscriptionResponseAsyncSequenceTests {
         let subscription = MessageSubscriptionResponseAsyncSequence(mockAsyncSequence: [].async) { _ in mockPaginatedResult }
 
         let result = try await subscription.historyBeforeSubscribe(withParams: .init())
-        #expect(result === mockPaginatedResult)
+        #expect(result as AnyObject === mockPaginatedResult as AnyObject)
     }
 }

--- a/Tests/AblyChatTests/MessageSubscriptionStorageTests.swift
+++ b/Tests/AblyChatTests/MessageSubscriptionStorageTests.swift
@@ -1,0 +1,71 @@
+@testable import AblyChat
+import AsyncAlgorithms
+import Foundation
+import Testing
+
+/// Tests proving that MessageSubscriptionResponseAsyncSequence can be stored as a property without needing to specify generic parameters.
+struct MessageSubscriptionStorageTests {
+    // MARK: - Can store as property
+
+    @Test
+    func canStoreSubscriptionAsProperty() async {
+        final class ChatManager {
+            var subscription: MessageSubscriptionResponseAsyncSequence?
+        }
+
+        let manager = ChatManager()
+        let mockSubscription = MessageSubscriptionResponseAsyncSequence(
+            mockAsyncSequence: [].async,
+        ) { _ in
+            fatalError("Not implemented")
+        }
+
+        // Can assign
+        manager.subscription = mockSubscription
+        #expect(manager.subscription != nil)
+
+        // Can clear
+        manager.subscription = nil
+        #expect(manager.subscription == nil)
+    }
+
+    // MARK: - Can iterate without try
+
+    /// This test proves that users can iterate over a stored subscription WITHOUT using `try`.
+    @Test
+    func canIterateWithoutTry() async {
+        final class ChatManager {
+            var subscription: MessageSubscriptionResponseAsyncSequence?
+
+            // This method is `async` not `async throws`
+            // It would fail to compile if `try` was needed to iterate
+            func processMessages() async -> [String] {
+                guard let subscription else {
+                    return []
+                }
+
+                var receivedTexts: [String] = []
+                for await event in subscription {
+                    receivedTexts.append(event.message.text)
+                }
+                return receivedTexts
+            }
+        }
+
+        let messages = [
+            Message(serial: "1", action: .messageCreate, clientID: "user1", text: "Hello", metadata: [:], headers: [:], version: .init(serial: "1", timestamp: Date()), timestamp: Date(), reactions: .empty),
+            Message(serial: "2", action: .messageCreate, clientID: "user2", text: "World", metadata: [:], headers: [:], version: .init(serial: "2", timestamp: Date()), timestamp: Date(), reactions: .empty),
+        ]
+        let events = messages.map { ChatMessageEvent(message: $0) }
+
+        let manager = ChatManager()
+        manager.subscription = MessageSubscriptionResponseAsyncSequence(
+            mockAsyncSequence: events.async,
+        ) { _ in
+            fatalError("Not implemented")
+        }
+
+        let receivedTexts = await manager.processMessages()
+        #expect(receivedTexts == ["Hello", "World"])
+    }
+}


### PR DESCRIPTION
The type was impossible for users to spell due to Swift compiler limitations with opaque types. historyBeforeSubscribe now returns `any PaginatedResult<Message>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the subscription response API by removing generic type parameters from return types, making the interface cleaner and more straightforward to use.

* **Tests**
  * Updated existing tests to align with API changes. Added comprehensive test coverage for subscription storage and iteration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->