### PR TITLE
Add dispose() method to ChatClient for resource cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ DerivedData/
 
 /node_modules
 /.mint
+.claude/settings.local.json

--- a/Example/AblyChatExample/Mocks/MockClients.swift
+++ b/Example/AblyChatExample/Mocks/MockClients.swift
@@ -20,6 +20,10 @@ class MockChatClient: ChatClientProtocol {
     var clientID: String? {
         "AblyTest"
     }
+
+    func dispose() async {
+        // No-op for mock
+    }
 }
 
 class MockRooms: Rooms {

--- a/Sources/AblyChat/ChatClient.swift
+++ b/Sources/AblyChat/ChatClient.swift
@@ -53,6 +53,20 @@ public protocol ChatClientProtocol: AnyObject, Sendable {
      * - Returns: The client options.
      */
     var clientOptions: ChatClientOptions { get }
+
+    /**
+     * Disposes of the chat client and releases all associated resources.
+     *
+     * Calling this method will:
+     * - Release all rooms managed by this client
+     * - Clean up connection listeners and timers
+     *
+     * After calling this method, the client should not be used. Attempting to get a room
+     * after dispose has been called will throw an error.
+     *
+     * This method is idempotent - calling it multiple times has no additional effect.
+     */
+    func dispose() async
 }
 
 @MainActor
@@ -130,6 +144,26 @@ public class ChatClient: ChatClientProtocol {
     // swiftlint:disable:next missing_docs
     public var clientID: String? {
         realtime.clientId
+    }
+
+    /// Whether this ChatClient has been disposed.
+    private var isDisposed = false
+
+    // @spec CHA-CL1
+    // swiftlint:disable:next missing_docs
+    public func dispose() async {
+        // Idempotency check
+        if isDisposed {
+            return
+        }
+
+        isDisposed = true
+
+        // CHA-CL1a: First, dispose of all rooms
+        await _rooms.dispose()
+
+        // CHA-CL1b: Then, dispose of connection instance
+        _connection.dispose()
     }
 }
 

--- a/Sources/AblyChat/DefaultConnection.swift
+++ b/Sources/AblyChat/DefaultConnection.swift
@@ -1,8 +1,15 @@
 import Ably
 
+@MainActor
 internal final class DefaultConnection: Connection {
     private let realtime: any InternalRealtimeClientProtocol
     private let timerManager = TimerManager(clock: SystemClock())
+
+    /// Track all event listeners we've created so we can clean them up on dispose.
+    private var eventListeners: [ARTEventListener] = []
+
+    /// Whether this Connection instance has been disposed.
+    private var isDisposed = false
 
     // (CHA-CS2a) The chat client must expose its current connection status.
     internal var status: ConnectionStatus {
@@ -24,54 +31,59 @@ internal final class DefaultConnection: Connection {
     internal func onStatusChange(_ callback: @escaping @MainActor (ConnectionStatusChange) -> Void) -> some StatusSubscription {
         // (CHA-CS5) The chat client must monitor the underlying realtime connection for connection status changes.
         let eventListener = realtime.connection.on { [weak self] stateChange in
-            guard let self else {
-                return
-            }
-            let currentState = ConnectionStatus.fromRealtimeConnectionState(stateChange.current)
-            let previousState = ConnectionStatus.fromRealtimeConnectionState(stateChange.previous)
+            Task { @MainActor in
+                guard let self else {
+                    return
+                }
+                let currentState = ConnectionStatus.fromRealtimeConnectionState(stateChange.current)
+                let previousState = ConnectionStatus.fromRealtimeConnectionState(stateChange.previous)
 
-            // (CHA-CS4a) Connection status update events must contain the newly entered connection status.
-            // (CHA-CS4b) Connection status update events must contain the previous connection status.
-            // (CHA-CS4c) Connection status update events must contain the connection error (if any) that pertains to the newly entered connection status.
-            let statusChange = ConnectionStatusChange(
-                current: currentState,
-                previous: previousState,
-                error: stateChange.reason,
-                // TODO: Actually emit `nil` when appropriate (we can't currently since ably-cocoa's corresponding property is mis-typed): https://github.com/ably/ably-chat-swift/issues/394
-                retryIn: stateChange.retryIn,
-            )
+                // (CHA-CS4a) Connection status update events must contain the newly entered connection status.
+                // (CHA-CS4b) Connection status update events must contain the previous connection status.
+                // (CHA-CS4c) Connection status update events must contain the connection error (if any) that pertains to the newly entered connection status.
+                let statusChange = ConnectionStatusChange(
+                    current: currentState,
+                    previous: previousState,
+                    error: stateChange.reason,
+                    // TODO: Actually emit `nil` when appropriate (we can't currently since ably-cocoa's corresponding property is mis-typed): https://github.com/ably/ably-chat-swift/issues/394
+                    retryIn: stateChange.retryIn,
+                )
 
-            let isTimerRunning = timerManager.hasRunningTask()
-            //  (CHA-CS5a) The chat client must suppress transient disconnection events. It is not uncommon for Ably servers to perform connection shedding to balance load, or due to retiring. Clients should not need to concern themselves with transient events.
+                let isTimerRunning = self.timerManager.hasRunningTask()
+                //  (CHA-CS5a) The chat client must suppress transient disconnection events. It is not uncommon for Ably servers to perform connection shedding to balance load, or due to retiring. Clients should not need to concern themselves with transient events.
 
-            // (CHA-CS5a2) If a transient disconnect timer is active and the realtime connection status changes to `DISCONNECTED` or `CONNECTING`, the library must not emit a status change.
-            if isTimerRunning, currentState == .disconnected || currentState == .connecting {
-                return
-            }
+                // (CHA-CS5a2) If a transient disconnect timer is active and the realtime connection status changes to `DISCONNECTED` or `CONNECTING`, the library must not emit a status change.
+                if isTimerRunning, currentState == .disconnected || currentState == .connecting {
+                    return
+                }
 
-            // (CHA-CS5a3) If a transient disconnect timer is active and the realtime connections status changes to `CONNECTED`, `SUSPENDED` or `FAILED`, the library shall cancel the transient disconnect timer. The superseding status change shall be emitted.
-            if isTimerRunning, currentState == .connected || currentState == .suspended || currentState == .failed {
-                timerManager.cancelTimer()
-                callback(statusChange)
-            }
-
-            // (CHA-CS5a1) If the realtime connection status transitions from `CONNECTED` to `DISCONNECTED`, the chat client connection status must not change. A 5 second transient disconnect timer shall be started.
-            if previousState == .connected, currentState == .disconnected, !isTimerRunning {
-                timerManager.setTimer(interval: 5.0) { [timerManager] in
-                    // (CHA-CS5a4) If a transient disconnect timer expires the library shall emit a connection status change event. This event must contain the current status of of timer expiry, along with the original error that initiated the transient disconnect timer.
-                    timerManager.cancelTimer()
+                // (CHA-CS5a3) If a transient disconnect timer is active and the realtime connections status changes to `CONNECTED`, `SUSPENDED` or `FAILED`, the library shall cancel the transient disconnect timer. The superseding status change shall be emitted.
+                if isTimerRunning, currentState == .connected || currentState == .suspended || currentState == .failed {
+                    self.timerManager.cancelTimer()
                     callback(statusChange)
                 }
-                return
-            }
 
-            if isTimerRunning {
-                timerManager.cancelTimer()
-            }
+                // (CHA-CS5a1) If the realtime connection status transitions from `CONNECTED` to `DISCONNECTED`, the chat client connection status must not change. A 5 second transient disconnect timer shall be started.
+                if previousState == .connected, currentState == .disconnected, !isTimerRunning {
+                    self.timerManager.setTimer(interval: 5.0) { [timerManager = self.timerManager] in
+                        // (CHA-CS5a4) If a transient disconnect timer expires the library shall emit a connection status change event. This event must contain the current status of of timer expiry, along with the original error that initiated the transient disconnect timer.
+                        timerManager.cancelTimer()
+                        callback(statusChange)
+                    }
+                    return
+                }
 
-            // (CHA-CS5b) Not withstanding CHA-CS5a. If a connection state event is observed from the underlying realtime library, the client must emit a status change event. The current status of that event shall reflect the status change in the underlying realtime library, along with the accompanying error.
-            callback(statusChange)
+                if isTimerRunning {
+                    self.timerManager.cancelTimer()
+                }
+
+                // (CHA-CS5b) Not withstanding CHA-CS5a. If a connection state event is observed from the underlying realtime library, the client must emit a status change event. The current status of that event shall reflect the status change in the underlying realtime library, along with the accompanying error.
+                callback(statusChange)
+            }
         }
+
+        // Track this listener so we can clean it up on dispose
+        eventListeners.append(eventListener)
 
         return DefaultStatusSubscription { [weak self] in
             guard let self else {
@@ -79,6 +91,37 @@ internal final class DefaultConnection: Connection {
             }
             timerManager.cancelTimer()
             realtime.connection.off(eventListener)
+            // Remove from tracked list
+            eventListeners.removeAll { $0 === eventListener }
         }
+    }
+
+    // @spec CHA-CL1b
+    /// Disposes of the connection, cleaning up any listeners and timers.
+    ///
+    /// This method:
+    /// 1. Cancels any active transient disconnect timers
+    /// 2. Removes all connection state listeners we've registered
+    ///
+    /// Note: We do NOT close the underlying realtime connection. The ARTRealtime instance
+    /// is owned by the user and passed to ChatClient.
+    ///
+    /// This method is idempotent.
+    internal func dispose() {
+        // Idempotency check
+        if isDisposed {
+            return
+        }
+
+        isDisposed = true
+
+        // Cancel any active transient disconnect timer
+        timerManager.cancelTimer()
+
+        // Remove all connection state listeners we've registered
+        for listener in eventListeners {
+            realtime.connection.off(listener)
+        }
+        eventListeners.removeAll()
     }
 }

--- a/Sources/AblyChat/DefaultMessageReactions.swift
+++ b/Sources/AblyChat/DefaultMessageReactions.swift
@@ -150,4 +150,10 @@ internal final class DefaultMessageReactions<Realtime: InternalRealtimeClientPro
 
         return summary
     }
+
+    /// Disposes of the message reactions feature.
+    /// This is a no-op as the feature has no internal state to clean up.
+    internal func dispose() {
+        // No internal state to clean up
+    }
 }

--- a/Sources/AblyChat/DefaultMessages.swift
+++ b/Sources/AblyChat/DefaultMessages.swift
@@ -12,9 +12,12 @@ internal final class DefaultMessages<Realtime: InternalRealtimeClientProtocol>: 
     private var currentSubscriptionPoint: String?
     private var subscriptionPoints: [UUID: String] = [:]
 
+    /// The channel state listener used to track subscription points.
+    private var channelStateListener: ARTEventListener?
+
     private func updateCurrentSubscriptionPoint() {
         currentSubscriptionPoint = channel.properties.attachSerial
-        _ = channel.on { [weak self] stateChange in
+        channelStateListener = channel.on { [weak self] stateChange in
             guard let self else {
                 return
             }
@@ -174,5 +177,21 @@ internal final class DefaultMessages<Realtime: InternalRealtimeClientProtocol>: 
 
     internal enum MessagesError: Error {
         case noReferenceToSelf
+    }
+
+    /// Disposes of the messages feature, cleaning up listeners and state.
+    internal func dispose() {
+        // Remove channel state listener
+        if let channelStateListener {
+            channel.off(channelStateListener)
+        }
+        channelStateListener = nil
+
+        // Clear subscription points
+        currentSubscriptionPoint = nil
+        subscriptionPoints.removeAll()
+
+        // Dispose of message reactions
+        reactions.dispose()
     }
 }

--- a/Sources/AblyChat/DefaultOccupancy.swift
+++ b/Sources/AblyChat/DefaultOccupancy.swift
@@ -74,4 +74,9 @@ internal final class DefaultOccupancy<Realtime: InternalRealtimeClientProtocol>:
         // CHA-07b
         return lastOccupancyData
     }
+
+    /// Disposes of the occupancy feature, clearing cached state.
+    internal func dispose() {
+        lastOccupancyData = nil
+    }
 }

--- a/Sources/AblyChat/DefaultTyping.swift
+++ b/Sources/AblyChat/DefaultTyping.swift
@@ -176,4 +176,9 @@ internal final class DefaultTyping: Typing {
             throw error
         }
     }
+
+    /// Disposes of the typing feature, cancelling all timers and clearing state.
+    internal func dispose() {
+        typingTimerManager.dispose()
+    }
 }

--- a/Sources/AblyChat/InternalError.swift
+++ b/Sources/AblyChat/InternalError.swift
@@ -78,6 +78,11 @@ internal enum InternalError {
     /// Error code is `invalidArgument`.
     case unableDeleteReactionWithoutName(reactionType: String)
 
+    /// The user tried to get a room from a client that has been disposed, per CHA-CL1.
+    ///
+    /// Error code is `resourceDisposed`.
+    case clientDisposed
+
     // MARK: - Errors not from the spec
 
     // TODO: Revisit the non-specified errors as part of https://github.com/ably/ably-chat-swift/issues/438
@@ -130,6 +135,7 @@ internal enum InternalError {
     internal enum ErrorCode: Int {
         case badRequest = 40000
         case invalidArgument = 40003
+        case resourceDisposed = 40014
         case roomDiscontinuity = 102_100
         case roomReleasedBeforeOperationCompleted = 102_106
         case roomExistsWithDifferentOptions = 102_107
@@ -141,6 +147,7 @@ internal enum InternalError {
             switch self {
             case .badRequest,
                  .invalidArgument,
+                 .resourceDisposed,
                  .roomReleasedBeforeOperationCompleted,
                  .roomInInvalidState,
                  .roomExistsWithDifferentOptions:
@@ -197,6 +204,8 @@ internal enum InternalError {
             .badRequest
         case .jsonValueDecodingError:
             .badRequest
+        case .clientDisposed:
+            .resourceDisposed
         }
     }
 
@@ -322,6 +331,9 @@ internal enum InternalError {
             case let .failedToDecodeFromRawValue(type: type, rawValue: rawValue):
                 reason = "could not decode \(type) from raw value \(rawValue)"
             }
+        case .clientDisposed:
+            op = "get room"
+            reason = "client has been disposed"
         }
 
         return "unable to \(op); \(reason)"
@@ -353,7 +365,8 @@ internal enum InternalError {
              .deleteMessageReactionEmptyMessageSerial,
              .noItemInResponse,
              .paginatedResultStatusCode,
-             .failedToResolveSubscriptionPointBecauseMessagesInstanceGone:
+             .failedToResolveSubscriptionPointBecauseMessagesInstanceGone,
+             .clientDisposed:
             nil
         }
     }

--- a/Sources/AblyChat/Room.swift
+++ b/Sources/AblyChat/Room.swift
@@ -386,6 +386,11 @@ internal class DefaultRoom<Realtime: InternalRealtimeClientProtocol, LifecycleMa
     internal func release() async {
         await lifecycleManager.performReleaseOperation()
 
+        // Dispose of room features to clean up any internal state
+        typing.dispose()
+        occupancy.dispose()
+        messages.dispose()
+
         // CHA-RL3h
         realtime.channels.release(internalChannel.name)
     }

--- a/Sources/AblyChat/Rooms.swift
+++ b/Sources/AblyChat/Rooms.swift
@@ -126,6 +126,9 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     /// The value for a given room name is the state that corresponds to that room name.
     private var roomStates: [String: RoomState] = [:]
 
+    /// Whether this Rooms instance has been disposed. Once true, `get` will throw.
+    private var isDisposed = false
+
     internal init(realtime: RoomFactory.Realtime, logger: any InternalLogger, roomFactory: RoomFactory) {
         self.realtime = realtime
         self.logger = logger
@@ -162,6 +165,11 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
     #endif
 
     internal func get(named name: String, options: RoomOptions) async throws(ErrorInfo) -> RoomFactory.Room {
+        // CHA-CL1a: Check if disposed before proceeding
+        if isDisposed {
+            throw InternalError.clientDisposed.toErrorInfo()
+        }
+
         if let existingRoomState = roomStates[name] {
             switch existingRoomState {
             case let .roomMapEntry(existingRoomMapEntry):
@@ -354,5 +362,38 @@ internal class DefaultRooms<RoomFactory: AblyChat.RoomFactory>: Rooms {
 
             await releaseTask.value
         }
+    }
+
+    // @spec CHA-CL1a
+    /// Disposes of all rooms managed by this instance.
+    ///
+    /// This method:
+    /// 1. Sets the disposed flag to prevent new room gets
+    /// 2. Releases all rooms concurrently
+    /// 3. Clears the internal room states map
+    ///
+    /// This method is idempotent.
+    internal func dispose() async {
+        // Idempotency check
+        if isDisposed {
+            return
+        }
+
+        isDisposed = true
+
+        // Collect all room names to release
+        let roomNamesToRelease = Array(roomStates.keys)
+
+        // Release all rooms concurrently using TaskGroup
+        await withTaskGroup(of: Void.self) { group in
+            for roomName in roomNamesToRelease {
+                group.addTask { @Sendable in
+                    await self.release(named: roomName)
+                }
+            }
+        }
+
+        // Ensure map is cleared (should already be empty after releases, but ensure cleanup)
+        roomStates.removeAll()
     }
 }

--- a/Sources/AblyChat/TypingTimerManager.swift
+++ b/Sources/AblyChat/TypingTimerManager.swift
@@ -85,6 +85,19 @@ internal final class TypingTimerManager<AnyClock: ClockProtocol>: TypingTimerMan
     internal func currentlyTypingClientIDs() -> Set<String> {
         Set(whoIsTypingTimers.keys)
     }
+
+    // (CHA-CL1) Called during client dispose to clean up typing timers.
+    /// Disposes of the typing timer manager, cancelling all active timers and clearing state.
+    internal func dispose() {
+        // Cancel heartbeat timer
+        cancelHeartbeatTimer()
+
+        // Cancel all "who is typing" timers
+        for (_, timer) in whoIsTypingTimers {
+            timer.cancelTimer()
+        }
+        whoIsTypingTimers.removeAll()
+    }
 }
 
 // Whilst this protocol seems redundant seeing as there's only a single implementation,
@@ -106,4 +119,7 @@ internal protocol TypingTimerManagerProtocol {
     func isCurrentlyTyping(clientID: String) -> Bool
     /// Returns the set of client IDs that we consider to currently be typing (also referred to in the spec as the "typing set").
     func currentlyTypingClientIDs() -> Set<String>
+    // (CHA-CL1) Called during client dispose to clean up typing timers.
+    /// Disposes of the typing timer manager, cancelling all active timers and clearing state.
+    func dispose()
 }

--- a/Tests/AblyChatTests/DisposeTests.swift
+++ b/Tests/AblyChatTests/DisposeTests.swift
@@ -1,0 +1,189 @@
+import Ably
+@testable import AblyChat
+import Testing
+
+@MainActor
+struct DefaultRoomsDisposeTests {
+    // MARK: - Test helpers
+
+    /// A mock implementation of an `InternalRoom`'s `release` operation. Its ``complete()`` method allows you to signal to the mock that the release should complete.
+    final class SignallableReleaseOperation: Sendable {
+        private let continuation: AsyncStream<Void>.Continuation
+
+        /// When this function is set as a ``MockRoom``'s `releaseImplementation`, calling ``complete()`` will cause the corresponding `release()` to complete with the result passed to that method.
+        let releaseImplementation: @Sendable () async -> Void
+
+        init() {
+            let (stream, continuation) = AsyncStream.makeStream(of: Void.self)
+            self.continuation = continuation
+
+            releaseImplementation = { @Sendable () async in
+                await (stream.first { _ in true })
+            }
+        }
+
+        /// Causes the async function embedded in ``releaseImplementation`` to return.
+        func complete() {
+            continuation.yield(())
+        }
+    }
+
+    // MARK: - Dispose tests
+
+    // @spec CHA-CL1a
+    @Test
+    func dispose_preventsSubsequentGetCalls() async throws {
+        // Given: an instance of DefaultRooms
+        let realtime = MockRealtime(channels: .init(channels: [
+            .init(name: "basketball::$chat"),
+        ]))
+        let options = RoomOptions()
+        let roomToReturn = MockRoom(options: options)
+        let roomFactory = MockRoomFactory(room: roomToReturn)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
+
+        // When: dispose() is called
+        await rooms.dispose()
+
+        // Then: Subsequent calls to get() throw a clientDisposed error
+        let thrownError = try await #require(throws: ErrorInfo.self) {
+            try await rooms.get(named: "basketball", options: options)
+        }
+        #expect(thrownError.hasCode(.resourceDisposed))
+        #expect(thrownError.message.contains("client has been disposed"))
+    }
+
+    // @spec CHA-CL1a
+    @Test
+    func dispose_releasesAllRooms() async throws {
+        // Given: an instance of DefaultRooms with multiple rooms
+        let realtime = MockRealtime(channels: .init(channels: [
+            .init(name: "basketball::$chat"),
+            .init(name: "football::$chat"),
+        ]))
+        let options = RoomOptions()
+
+        let room1ReleaseOperation = SignallableReleaseOperation()
+        let room1 = MockRoom(options: options, releaseImplementation: room1ReleaseOperation.releaseImplementation)
+
+        let room2ReleaseOperation = SignallableReleaseOperation()
+        let room2 = MockRoom(options: options, releaseImplementation: room2ReleaseOperation.releaseImplementation)
+
+        let roomFactory = MockRoomFactory()
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
+
+        // Get room1
+        roomFactory.setRoom(room1)
+        _ = try await rooms.get(named: "basketball", options: options)
+
+        // Get room2
+        roomFactory.setRoom(room2)
+        _ = try await rooms.get(named: "football", options: options)
+
+        // When: dispose() is called
+        async let disposeTask: Void = rooms.dispose()
+
+        // Allow the release operations to complete
+        room1ReleaseOperation.complete()
+        room2ReleaseOperation.complete()
+
+        await disposeTask
+
+        // Then: Both rooms had release() called
+        #expect(room1.releaseCallCount == 1)
+        #expect(room2.releaseCallCount == 1)
+    }
+
+    // @spec CHA-CL1a
+    @Test
+    func dispose_isIdempotent() async throws {
+        // Given: an instance of DefaultRooms that has already been disposed
+        let realtime = MockRealtime(channels: .init(channels: [
+            .init(name: "basketball::$chat"),
+        ]))
+        let roomFactory = MockRoomFactory()
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
+
+        await rooms.dispose()
+
+        // When: dispose() is called again
+        // Then: No error is thrown and operation completes
+        await rooms.dispose()
+    }
+
+    // @spec CHA-CL1a
+    @Test
+    func dispose_clearsRoomStates() async throws {
+        // Given: an instance of DefaultRooms with a room
+        let realtime = MockRealtime(channels: .init(channels: [
+            .init(name: "basketball::$chat"),
+        ]))
+        let options = RoomOptions()
+
+        let roomReleaseOperation = SignallableReleaseOperation()
+        let roomToReturn = MockRoom(options: options, releaseImplementation: roomReleaseOperation.releaseImplementation)
+        let roomFactory = MockRoomFactory(room: roomToReturn)
+        let rooms = DefaultRooms(realtime: realtime, logger: TestLogger(), roomFactory: roomFactory)
+
+        _ = try await rooms.get(named: "basketball", options: options)
+        #expect(rooms.testsOnly_hasRoomMapEntryWithName("basketball"))
+
+        // When: dispose() is called
+        async let disposeTask: Void = rooms.dispose()
+        roomReleaseOperation.complete()
+        await disposeTask
+
+        // Then: Room states are cleared
+        #expect(!rooms.testsOnly_hasRoomMapEntryWithName("basketball"))
+    }
+}
+
+@MainActor
+struct TypingTimerManagerDisposeTests {
+    @available(iOS 16.0, tvOS 16, *)
+    private func createTypingTimerManager(with testClock: MockTestClock) -> TypingTimerManager<MockTestClock> {
+        TypingTimerManager(
+            heartbeatThrottle: 5.0,
+            gracePeriod: 2.0,
+            logger: TestLogger(),
+            clock: testClock,
+        )
+    }
+
+    // @spec CHA-CL1a (typing cleanup)
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func dispose_clearsHeartbeatTimer() async throws {
+        // Given: a TypingTimerManager with an active heartbeat timer
+        let clock = MockTestClock()
+        let manager = createTypingTimerManager(with: clock)
+
+        manager.startHeartbeatTimer()
+        #expect(manager.isHeartbeatTimerActive)
+
+        // When: dispose() is called
+        manager.dispose()
+
+        // Then: The heartbeat timer is cleared
+        #expect(!manager.isHeartbeatTimerActive)
+    }
+
+    // @spec CHA-CL1a (typing cleanup)
+    @Test
+    @available(iOS 16.0, tvOS 16, *)
+    func dispose_clearsWhoIsTypingTimers() async throws {
+        // Given: a TypingTimerManager with active "who is typing" timers
+        let clock = MockTestClock()
+        let manager = createTypingTimerManager(with: clock)
+
+        manager.startTypingTimer(for: "client1")
+        manager.startTypingTimer(for: "client2")
+        #expect(manager.currentlyTypingClientIDs() == Set(["client1", "client2"]))
+
+        // When: dispose() is called
+        manager.dispose()
+
+        // Then: All "who is typing" timers are cleared
+        #expect(manager.currentlyTypingClientIDs().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `dispose()` method on `ChatClient` to allow explicit disposal of the chat client and release of all associated resources (CHA-CL1 spec item).

PR to fix spec: https://github.com/ably/specification/pull/422

## Changes

- Add `dispose()` to `ChatClientProtocol` and `ChatClient` implementation
- Add `dispose()` to `DefaultRooms` that releases all rooms concurrently
- Add `dispose()` to room features that have internal state:
  - `DefaultMessages` - cleans up subscription point continuations
  - `DefaultTyping` - invalidates typing timers via `TypingTimerManager`
  - `DefaultOccupancy` - cleans up internal state
  - `DefaultConnection` - removes event listeners
  - `DefaultMessageReactions` - no-op (no internal state)
- Add `clientDisposed` error case with error code 40014 (`resourceDisposed`)
- Call feature `dispose()` methods during room release

## Behavior

- After disposal, attempting to get a room throws an error
- The `dispose()` method is idempotent - calling it multiple times has no additional effect
- Rooms are released concurrently during disposal

## Test Plan

Added `DisposeTests.swift` with tests covering:
- Client disposal prevents getting rooms
- Idempotent disposal behavior
- Room release during disposal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async dispose() to the client to gracefully release resources; idempotent and prevents further operations with a clear error.

* **Behavior Changes**
  * Disposal now cleans up rooms, message/typing/occupancy state, timers, and event listeners to avoid leaks and stale state.

* **Tests**
  * New tests validating disposal behavior, idempotency, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->