### PR TITLE
Upgrades Xcode runner from 26.0 to 26.2

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,7 +23,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 26 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.0
+          xcode-version: 26.2
 
       # We use caching for Mint because at the time of writing SwiftLint took about 5 minutes to build in CI, which is unacceptably slow.
       # https://github.com/actions/cache/blob/40c3b67b2955d93d83b27ed164edd0756bc24049/examples.md#swift---mint
@@ -50,7 +50,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.0
+          xcode-version: 26.2
 
       - name: Spec coverage
         run: swift run BuildTool spec-coverage
@@ -69,7 +69,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.0
+          xcode-version: 26.2
 
       - id: generation-step
         run: swift run BuildTool generate-matrices >> $GITHUB_OUTPUT
@@ -151,7 +151,7 @@ jobs:
   #      # This step can be removed once the runners’ default version of Xcode is 16 or above
   #      - uses: maxim-lobanov/setup-xcode@v1
   #        with:
-  #          xcode-version: 26.0
+  #          xcode-version: 26.2
   #
   #      - run: swift run BuildTool generate-code-coverage --result-bundle-path CodeCoverage.xcresult
   #
@@ -228,7 +228,7 @@ jobs:
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 26.0
+          xcode-version: 26.2
 
       # Dry run upload-action to get base-path url
       - name: Dry-Run Upload (to get url)

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -134,7 +134,7 @@ struct GenerateMatrices: ParsableCommand {
     )
 
     mutating func run() throws {
-        let tooling = ["26.0"].map { xcodeVersion in
+        let tooling = ["26.2"].map { xcodeVersion in
             [
                 "xcodeVersion": xcodeVersion,
             ]

--- a/Sources/BuildTool/Platform.swift
+++ b/Sources/BuildTool/Platform.swift
@@ -11,9 +11,9 @@ enum Platform: String, CaseIterable {
         case .macOS:
             .fixed(platform: "macOS")
         case .iOS:
-            .lookup(destinationPredicate: .init(runtime: "iOS-26-0", deviceType: "iPhone-17"))
+            .lookup(destinationPredicate: .init(runtime: "iOS-26-2", deviceType: "iPhone-17-Pro"))
         case .tvOS:
-            .lookup(destinationPredicate: .init(runtime: "tvOS-26-0", deviceType: "Apple-TV-4K-3rd-generation-4K"))
+            .lookup(destinationPredicate: .init(runtime: "tvOS-26-2", deviceType: "Apple-TV-4K-3rd-generation-4K"))
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Xcode version requirement from 26.0 to 26.2 across build tools and CI/CD workflows.
  * Updated iOS and tvOS simulator targets to use latest compatible runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->