### PR TITLE
[ECO-5702] Fix Xcode 26.4 compilation error

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,7 +8,7 @@ on:
       - main
 jobs:
   lint:
-    runs-on: macos-15
+    runs-on: macos-26
 
     # From actions/cache documentation linked to below
     env:
@@ -41,7 +41,7 @@ jobs:
       - run: swift run BuildTool lint
 
   spec-coverage:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-matrices:
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   build-and-test-spm:
     name: SPM (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-15
+    runs-on: macos-26
     needs: generate-matrices
     strategy:
       fail-fast: false
@@ -96,7 +96,7 @@ jobs:
 
   build-release-configuration-spm:
     name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-15
+    runs-on: macos-26
     needs: generate-matrices
     strategy:
       fail-fast: false
@@ -115,7 +115,7 @@ jobs:
 
   build-and-test-xcode:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-15
+    runs-on: macos-26
     needs: generate-matrices
 
     strategy:
@@ -141,7 +141,7 @@ jobs:
   # TODO: Disabled after this started failing when we switched to Xcode 26; investigate https://github.com/ably/ably-chat-swift/issues/361
   #  code-coverage:
   #    name: Generate code coverage
-  #    runs-on: macos-15
+  #    runs-on: macos-26
   #
   #    steps:
   #      - uses: actions/checkout@v4
@@ -174,7 +174,7 @@ jobs:
 
   build-release-configuration-xcode:
     name: Xcode, `release` configuration, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-15
+    runs-on: macos-26
     needs: generate-matrices
 
     strategy:
@@ -194,7 +194,7 @@ jobs:
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
-    runs-on: macos-15
+    runs-on: macos-26
     needs: generate-matrices
 
     strategy:
@@ -213,7 +213,7 @@ jobs:
         run: swift run BuildTool build-example-app --platform ${{ matrix.platform }}
 
   check-documentation:
-    runs-on: macos-15
+    runs-on: macos-26
 
     permissions:
       deployments: write

--- a/Sources/AblyChat/TypingOperationQueue.swift
+++ b/Sources/AblyChat/TypingOperationQueue.swift
@@ -34,6 +34,7 @@ internal class TypingOperationQueue<Failure: Error> {
         }
 
         /// Executes the requested operation, and causes this request's call to `enqueue` to complete with the result of the execution.
+        @MainActor
         func performOperation() async {
             let result = await operation()
             complete(with: result)

--- a/Sources/BuildTool/BuildTool.swift
+++ b/Sources/BuildTool/BuildTool.swift
@@ -134,7 +134,7 @@ struct GenerateMatrices: ParsableCommand {
     )
 
     mutating func run() throws {
-        let tooling = ["26.2"].map { xcodeVersion in
+        let tooling = ["26.4"].map { xcodeVersion in
             [
                 "xcodeVersion": xcodeVersion,
             ]


### PR DESCRIPTION
Resolves https://github.com/ably/ably-cocoa/issues/2202. See commit message for more details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD pipeline runner configuration to macOS 26 across all build jobs for improved compatibility and stability
  * Updated Xcode build tooling to version 26.4
  * Enhanced thread safety in asynchronous request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->