### PR TITLE
ci: GitHub Actions workflow security cleanup

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
 
       # This step can be removed once the runners’ default version of Xcode is 26 or above
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -75,6 +77,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -98,6 +101,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
@@ -120,6 +124,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
@@ -143,6 +148,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
@@ -205,6 +211,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
@@ -228,6 +235,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
@@ -247,6 +255,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
+          persist-credentials: false
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,15 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   lint:
     runs-on: macos-26
+
+    permissions:
+      contents: read
 
     # From actions/cache documentation linked to below
     env:
@@ -42,6 +48,8 @@ jobs:
 
   spec-coverage:
     runs-on: macos-26
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -59,6 +67,8 @@ jobs:
 
   generate-matrices:
     runs-on: macos-26
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
@@ -78,6 +88,8 @@ jobs:
     name: SPM (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-26
     needs: generate-matrices
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
@@ -98,6 +110,8 @@ jobs:
     name: SPM, `release` configuration (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-26
     needs: generate-matrices
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
@@ -117,6 +131,9 @@ jobs:
     name: Xcode, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-26
     needs: generate-matrices
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -177,6 +194,9 @@ jobs:
     runs-on: macos-26
     needs: generate-matrices
 
+    permissions:
+      contents: read
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
@@ -196,6 +216,9 @@ jobs:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
     runs-on: macos-26
     needs: generate-matrices
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -272,6 +295,7 @@ jobs:
   # tweak the matrices).
   all-checks-completed:
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - lint
       - spec-coverage

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,18 +16,18 @@ jobs:
       MINT_LINK_PATH: .mint/bin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
       # This step can be removed once the runners’ default version of Xcode is 26 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: 26.2
 
       # We use caching for Mint because at the time of writing SwiftLint took about 5 minutes to build in CI, which is unacceptably slow.
       # https://github.com/actions/cache/blob/40c3b67b2955d93d83b27ed164edd0756bc24049/examples.md#swift---mint
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .mint
           key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
@@ -43,12 +43,12 @@ jobs:
   spec-coverage:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: 26.2
 
@@ -62,12 +62,12 @@ jobs:
     outputs:
       matrix: ${{ steps.generation-step.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: 26.2
 
@@ -83,10 +83,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -103,10 +103,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withoutPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -123,10 +123,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -144,12 +144,12 @@ jobs:
   #    runs-on: macos-26
   #
   #    steps:
-  #      - uses: actions/checkout@v4
+  #      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
   #        with:
   #          submodules: true
   #
   #      # This step can be removed once the runners’ default version of Xcode is 16 or above
-  #      - uses: maxim-lobanov/setup-xcode@v1
+  #      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
   #        with:
   #          xcode-version: 26.2
   #
@@ -182,10 +182,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -202,10 +202,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrices.outputs.matrix).withPlatform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
@@ -221,19 +221,19 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: true
 
       # This step can be removed once the runners’ default version of Xcode is 16 or above
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: 26.2
 
       # Dry run upload-action to get base-path url
       - name: Dry-Run Upload (to get url)
         id: preupload
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2.2.0
         with:
           mode: preempt
           sourcePath: .build/plugins/Swift-DocC/outputs/AblyChat.doccarchive # Path to the Swift DocC output folder
@@ -250,7 +250,7 @@ jobs:
 
       # Configure AWS credentials for uploading documentation
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-chat-swift
@@ -258,7 +258,7 @@ jobs:
 
       # Upload the generated documentation
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v2
+        uses: ably/sdk-upload-action@4e694297f208b72b5a9f6b1248a1556f19f821d6 # v2.2.0
         with:
           sourcePath: .build/plugins/Swift-DocC/outputs/AblyChat.doccarchive # Path to the Swift DocC output folder
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -156,10 +156,14 @@ jobs:
       # We run these as two separate steps so that we can easily see the execution time of each step.
 
       - name: Build for testing
-        run: swift run BuildTool build-library-for-testing --platform ${{ matrix.platform }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-library-for-testing --platform "$PLATFORM"
 
       - name: Run tests
-        run: swift run BuildTool test-library --platform ${{ matrix.platform }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool test-library --platform "$PLATFORM"
 
   # TODO: Disabled after this started failing when we switched to Xcode 26; investigate https://github.com/ably/ably-chat-swift/issues/361
   #  code-coverage:
@@ -217,7 +221,9 @@ jobs:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
       - name: Build library
-        run: swift run BuildTool build-library --platform ${{ matrix.platform }} --configuration release
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-library --platform "$PLATFORM" --configuration release
 
   check-example-app:
     name: Example app, ${{matrix.platform}} (Xcode ${{ matrix.tooling.xcodeVersion }})
@@ -241,7 +247,9 @@ jobs:
           xcode-version: ${{ matrix.tooling.xcodeVersion }}
 
       - name: Build example app
-        run: swift run BuildTool build-example-app --platform ${{ matrix.platform }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: swift run BuildTool build-example-app --platform "$PLATFORM"
 
   check-documentation:
     runs-on: macos-26
@@ -274,9 +282,11 @@ jobs:
 
       # Build the documentation using Swift DocC
       - name: Build documentation
+        env:
+          HOSTING_BASE_PATH: ${{ steps.preupload.outputs.base-path }}
         run: |
           swift package generate-documentation --target AblyChat --disable-indexing \
-          --hosting-base-path "${{ steps.preupload.outputs.base-path }}" \
+          --hosting-base-path "$HOSTING_BASE_PATH" \
           --transform-for-static-hosting
         working-directory: ${{ github.workspace }}
 


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:

  - Disable credential persistence on `actions/checkout` steps so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
  - Scope each job's permissions explicitly: top-level `permissions: {}`, with each job granted only the `GITHUB_TOKEN` scopes it actually needs.
  - Move workflow-context expansions (`${{ matrix.platform }}`, step outputs) out of `run:` shell source and into `env:` bindings.
  - Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

  No behavioural changes intended — the workflow runs the same checks against the same inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance security and build stability through dependency pinning and explicit permission controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ably/ably-chat-swift/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->